### PR TITLE
Feature/true sftp support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["process-mux"]
 process-mux = []
 native-mux = ["openssh-mux-client"]
+sftp = ["openssh-sftp-client"]
 
 [dependencies]
 tempfile = "3.1.0"
@@ -48,6 +49,8 @@ once_cell = "1.8.0"
 dirs = "4.0.0"
 
 openssh-mux-client = { version = "0.14.4", optional = true }
+
+openssh-sftp-client = { version = "0.8.3", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -33,8 +33,20 @@ function cleanup {
 }
 trap cleanup EXIT
 
+function cleanup {
+    ssh-agent -k
+}
+trap cleanup EXIT
+
 echo Run tests
 rm -rf control-test config-file-test .ssh-connection*
+
+# Sftp integration tests creates files and directories in /tmp.
+# Normally, these tests would remove any files and directories created in /tmp,
+# but in case they fail, these files will be left there and
+# interfere with the next integration test.
+echo "Remove all files in /tmp in the container"
+docker exec -it openssh bash -c 'rm -rf /tmp/*'
 
 echo Running integration test
 cargo test \

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -11,6 +11,9 @@ use crate::*;
 ///  - Associated function [`SessionBuilder::compression`]
 ///  - Associated function [`SessionBuilder::user_known_hosts_file`]
 ///  - Associated function [`Session::control_socket`] for non-Windows platform.
+///  - Feature `sftp`.
+///  - New mod [`sftp`], contains the new, true Sftp implementation.
+///  - Associated function [`Session::sftp`]
 ///
 /// ## Changed
 ///  - Make [`ChildStdin`] an opaque type.

--- a/src/child.rs
+++ b/src/child.rs
@@ -39,6 +39,7 @@ macro_rules! delegate {
         }
     }};
 }
+pub(crate) use delegate;
 
 /// Representation of a running or exited remote child process.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -223,7 +223,7 @@ mod tests {
         let target = io::Error::new(io::ErrorKind::PermissionDenied, "openssh-tester@login.csail.mit.edu: Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password,keyboard-interactive).");
         if let Error::Connect(e) = err {
             assert_eq!(e.kind(), target.kind());
-            assert_eq!(format!("{}", e), format!("{}", target));
+            assert_eq!(e.to_string(), target.to_string());
         } else {
             unreachable!("{:?}", err);
         }
@@ -237,47 +237,47 @@ mod tests {
         let expect = ioe();
 
         let e = Error::Master(ioe());
-        assert!(!format!("{}", e).is_empty());
+        assert!(!e.to_string().is_empty());
         let e = e
             .source()
             .expect("source failed")
             .downcast_ref::<io::Error>()
             .expect("source not io");
         assert_eq!(e.kind(), expect.kind());
-        assert_eq!(format!("{}", e), format!("{}", expect));
+        assert_eq!(e.to_string(), expect.to_string());
 
         let e = Error::Connect(ioe());
-        assert!(!format!("{}", e).is_empty());
+        assert!(!e.to_string().is_empty());
         let e = e
             .source()
             .expect("source failed")
             .downcast_ref::<io::Error>()
             .expect("source not io");
         assert_eq!(e.kind(), expect.kind());
-        assert_eq!(format!("{}", e), format!("{}", expect));
+        assert_eq!(e.to_string(), expect.to_string());
 
         #[cfg(feature = "process-mux")]
         {
             let e = Error::Ssh(ioe());
-            assert!(!format!("{}", e).is_empty());
+            assert!(!e.to_string().is_empty());
             let e = e
                 .source()
                 .expect("source failed")
                 .downcast_ref::<io::Error>()
                 .expect("source not io");
             assert_eq!(e.kind(), expect.kind());
-            assert_eq!(format!("{}", e), format!("{}", expect));
+            assert_eq!(e.to_string(), expect.to_string());
         }
 
         let e = Error::Remote(ioe());
-        assert!(!format!("{}", e).is_empty());
+        assert!(!e.to_string().is_empty());
         let e = e
             .source()
             .expect("source failed")
             .downcast_ref::<io::Error>()
             .expect("source not io");
         assert_eq!(e.kind(), expect.kind());
-        assert_eq!(format!("{}", e), format!("{}", expect));
+        assert_eq!(e.to_string(), expect.to_string());
 
         let e = Error::Disconnected;
         assert!(!format!("{}", e).is_empty());

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,11 @@ pub enum Error {
 
     /// IO Error when creating/reading/writing from ChildStdin, ChildStdout, ChildStderr.
     ChildIo(io::Error),
+
+    /// Sftp error
+    #[cfg(feature = "sftp")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sftp")))]
+    SftpError(openssh_sftp_client::Error),
 }
 
 #[cfg(feature = "native-mux")]
@@ -80,6 +85,13 @@ impl From<openssh_mux_client::Error> for Error {
             },
             _ => Error::SshMux(err),
         }
+    }
+}
+
+#[cfg(feature = "sftp")]
+impl From<openssh_sftp_client::Error> for Error {
+    fn from(err: openssh_sftp_client::Error) -> Self {
+        Error::SftpError(err)
     }
 }
 
@@ -106,6 +118,9 @@ impl fmt::Display for Error {
 
             #[cfg(feature = "native-mux")]
             Error::InvalidCommand => write!(f, "invalid command: Command contains null byte."),
+
+            #[cfg(feature = "sftp")]
+            Error::SftpError(ref sftp_error) => write!(f, "Sftp error: {}", sftp_error),
         }
     }
 }
@@ -129,6 +144,9 @@ impl std::error::Error for Error {
 
             #[cfg(feature = "native-mux")]
             Error::SshMux(ref e) => Some(e),
+
+            #[cfg(feature = "sftp")]
+            Error::SftpError(ref e) => Some(e),
         }
     }
 }

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -118,6 +118,26 @@ impl Session {
         }
     }
 
+    #[cfg(feature = "sftp")]
+    pub(crate) async fn sftp(
+        &self,
+    ) -> Result<(super::RemoteChild, super::ChildStdin, super::ChildStdout), Error> {
+        let mut cmd = self.new_cmd(&["-T", "-p", "9"]);
+
+        // -s enables ssh subsystem
+        cmd.args(&["-s", "--", "sftp"]);
+
+        let mut cmd = Command::new(cmd);
+
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::null());
+
+        let (remote_child, stdin, stdout, _stderr) = cmd.spawn().await?;
+
+        Ok((remote_child, stdin.unwrap(), stdout.unwrap()))
+    }
+
     pub(crate) async fn close(mut self) -> Result<(), Error> {
         let mut exit_cmd = self.new_cmd(&["-O", "exit"]);
 

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -1,0 +1,137 @@
+use super::child::{delegate, RemoteChildImp};
+use super::{ChildStdin, ChildStdout, Error, Session};
+
+use openssh_sftp_client::highlevel;
+use std::marker::PhantomData;
+use std::path::Path;
+use std::process::ExitStatus;
+
+pub use highlevel::{
+    CancellationToken, DirEntry, FileType, MetaData, MetaDataBuilder, Permissions, ReadDir,
+    SftpOptions, UnixTimeStamp, UnixTimeStampError,
+};
+
+/// Options and flags which can be used to configure how a file is opened.
+pub type OpenOptions<'s> = highlevel::OpenOptions<'s, ChildStdin>;
+
+/// A reference to the remote file.
+///
+/// Cloning [`File`] instance would return a new one that shares the same
+/// underlying file handle as the existing File instance, while reads, writes
+/// and seeks can be performed independently.
+///
+/// If you want a file that implements [`tokio::io::AsyncRead`] and
+/// [`tokio::io::AsyncWrite`], checkout [`TokioCompactFile`].
+pub type File<'s> = highlevel::File<'s, ChildStdin>;
+
+/// File that implements [`tokio::io::AsyncRead`], [`tokio::io::AsyncBufRead`],
+/// [`tokio::io::AsyncSeek`] and [`tokio::io::AsyncWrite`], which is compatible
+/// with
+/// [`tokio::fs::File`](https://docs.rs/tokio/latest/tokio/fs/struct.File.html).
+pub type TokioCompatFile<'s> = highlevel::TokioCompatFile<'s, ChildStdin>;
+
+/// A struct used to perform operations on remote filesystem.
+pub type Fs<'s> = highlevel::Fs<'s, ChildStdin>;
+
+/// Remote Directory
+pub type Dir<'s> = highlevel::Dir<'s, ChildStdin>;
+
+/// Builder for new directory to create.
+pub type DirBuilder<'a, 's> = highlevel::DirBuilder<'a, 's, ChildStdin>;
+
+/// A file-oriented channel to a remote host.
+#[derive(Debug)]
+pub struct Sftp<'s> {
+    phantom_data: PhantomData<&'s Session>,
+    child: RemoteChildImp,
+
+    inner: highlevel::Sftp<ChildStdin>,
+}
+
+impl<'s> Sftp<'s> {
+    pub(crate) async fn new(
+        child: RemoteChildImp,
+        stdin: ChildStdin,
+        stdout: ChildStdout,
+        options: SftpOptions,
+    ) -> Result<Sftp<'s>, Error> {
+        Ok(Self {
+            phantom_data: PhantomData,
+            child,
+
+            inner: highlevel::Sftp::new(stdin, stdout, options).await?,
+        })
+    }
+
+    /// Close sftp connection
+    pub async fn close(self) -> Result<(), Error> {
+        self.inner.close().await?;
+
+        let res: Result<ExitStatus, Error> = delegate!(self.child, child, { child.wait().await });
+        let exit_status = res?;
+
+        if !exit_status.success() {
+            Err(Error::SftpError(
+                openssh_sftp_client::Error::SftpServerFailure(exit_status),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Return a new [`OpenOptions`] object.
+    pub fn options(&self) -> OpenOptions<'_> {
+        self.inner.options()
+    }
+
+    /// Opens a file in write-only mode.
+    ///
+    /// This function will create a file if it does not exist, and will truncate
+    /// it if it does.
+    pub async fn create(&self, path: impl AsRef<Path>) -> Result<File<'_>, Error> {
+        self.inner.create(path.as_ref()).await.map_err(Into::into)
+    }
+
+    /// Attempts to open a file in read-only mode.
+    pub async fn open(&self, path: impl AsRef<Path>) -> Result<File<'_>, Error> {
+        self.inner.open(path.as_ref()).await.map_err(Into::into)
+    }
+
+    /// [`Fs`] defaults to the current working dir set by remote `sftp-server`,
+    /// which usually is the home directory.
+    pub fn fs(&self) -> Fs<'_> {
+        self.inner.fs()
+    }
+
+    /// Triggers the flushing of the internal buffer in `flush_task`.
+    ///
+    /// If there are pending requests, then flushing would happen immediately.
+    ///
+    /// If not, then the next time a request is queued in the write buffer, it
+    /// will be immediately flushed.
+    pub fn trigger_flushing(&self) {
+        self.inner.trigger_flushing()
+    }
+
+    /// The maximum amount of bytes that can be written in one request.
+    /// Writing more than that, then your write will be split into multiple requests
+    ///
+    /// If [`Sftp::max_buffered_write`] is less than [`max_atomic_write_len`],
+    /// then the direct write is enabled and [`Sftp::max_write_len`] must be
+    /// less than [`max_atomic_write_len`].
+    pub fn max_write_len(&self) -> u32 {
+        self.inner.max_write_len()
+    }
+
+    /// The maximum amount of bytes that can be read in one request.
+    /// Reading more than that, then your read will be split into multiple requests
+    pub fn max_read_len(&self) -> u32 {
+        self.inner.max_read_len()
+    }
+
+    /// Get maximum amount of bytes that [`crate::highlevel::File`] and
+    /// [`crate::highlevel::TokioCompactFile`] would write in a buffered manner.
+    pub fn max_buffered_write(&self) -> u32 {
+        self.inner.max_buffered_write()
+    }
+}

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -128,6 +128,21 @@ impl_try_from_tokio_process_child_for_stdio!(ChildStderr);
 #[derive(Debug)]
 pub struct ChildStdin(tokio_pipe::PipeWrite);
 
+#[cfg(feature = "sftp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sftp")))]
+impl openssh_sftp_client::Writer for ChildStdin {
+    const MAX_ATOMIC_WRITE_LEN: usize =
+        <tokio_pipe::PipeWrite as openssh_sftp_client::Writer>::MAX_ATOMIC_WRITE_LEN;
+
+    fn poll_write_vectored_atomic(
+        &self,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<()>> {
+        self.0.poll_write_vectored_atomic(cx, bufs)
+    }
+}
+
 /// Stdout for the remote child.
 #[derive(Debug)]
 pub struct ChildStdout(tokio_pipe::PipeRead);


### PR DESCRIPTION
This is a draft PR for true sftp support using [NobodyXu/openssh-sftp-client].

This PR renames the original `Sftp` implementation to `Scp`.

This PR is intended to provide an API as close to [`tokio::fs::File`] as possible so that it be used with relative ease and is compatible with existing generic functions.

Currently, the following are the aspects of the PR that required careful reviewing:
 - Implementation of [`tokio::io::AsyncRead`] and [`tokio::io::AsyncWrite`] for `sftp::TokioCompactFile` contains hack.
   
   Both store the futures in `sftp::TokioCompactFile`.
   
   [`tokio::io::AsyncWrite::poll_write`] and [`tokio::io::AsyncWrite::poll_write_vectored`] for `sftp::TokioCompactFile` only copies the data to the buffer and requires [`tokio::io::AsyncWrite::poll_flush`] to be called to flush the data to the remote server and obtain the errors if any.
 - [`tokio::io::AsyncSeek`] does not send any requests since sftp v3 does not support seeking.
   
   Instead, it adjust field `sftp::File::offset`, which takes effect at next reading/writing.
   
   It also does not support [`std::io::SeekFrom::End`].
 - ~~`sftp::Sftp` only automatically flushes the write buffer for all requests (not just read and write, but also `sftp::File::set_len` and etc) every 0.9 ms.~~
    
    Flush interval of `sftp::Sftp` can now be configured by user.
 - ~~`sftp::Sftp` is huge, containing many fields.~~
 - ~~`sftp::File` is huge (at least `80` bytes large), containing many fields.~~
  `sftp::File` is `96` bytes large while [`tokio::fs::File`] in 1.16.1 is `112` bytes large on x86-64 and [`tokio::fs::File`] in 1.15 is [`104` bytes large](https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=4e6fc899cff0945d41df6031fcf725c3).
 - ~~Reading from `sftp::File` would copy the data from internal buffer.~~
 - Reading from `sftp::TokioCompactFile` would copy from internal buffer.

TODO:
 - [x] Report error in `AsyncRead::poll_read`, `AsyncWrite::poll_flush` if `read_task` or `write_task` failed.
 - [x] Add integration tests.
 - [x] Improving API and implementations.
 - [x] Support zero copy writing/reading.
 - [x] Support `read_dir`.
 - [x] Support `create_dir`.
 - [x] Support `remove_dir`.
 - [x] Support `remove_file`.
 - [x] Support `canonicalize`.
 - [x] Support `hard_link`.
 - [x] Support `symlink`.
 - [x] Support `rename`.
 - [x] Support `read_link`.
 - [x] Support `set_permission`.
 - [x] Support `metadata`.
 - [x] Support `symlink_metadata`.

This PR fixes #15 .

[NobodyXu/openssh-sftp-client]: https://github.com/NobodyXu/openssh-sftp-client
[`tokio::fs::File`]: https://docs.rs/tokio/latest/tokio/fs/struct.File.html
[`tokio::io::AsyncRead`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html
[`tokio::io::AsyncWrite`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html
[`tokio::io::AsyncWrite::poll_write`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html#tymethod.poll_write
[`tokio::io::AsyncWrite::poll_write_vectored`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html#tymethod.poll_write_vectored
[`tokio::io::AsyncWrite::poll_flush`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html#tymethod.poll_flush
[`tokio::io::AsyncSeek`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncSeek.html
[`std::io::SeekFrom::End`]: https://doc.rust-lang.org/stable/std/io/enum.SeekFrom.html#variant.End