### PR TITLE
Expose a Session's control socket path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ impl Session {
     }
 
     /// Get the SSH connection's control socket path.
-    pub fn ctl(&self) -> &Path {
+    pub fn control_socket(&self) -> &Path {
         delegate!(&self.0, imp, { imp.ctl() })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@ compile_error!("This crate can only be used on unix");
 
 use std::borrow::Cow;
 use std::ffi::OsStr;
+use std::path::Path;
 
 mod stdio;
 pub use stdio::{ChildStderr, ChildStdin, ChildStdout, Stdio};
@@ -289,6 +290,11 @@ impl Session {
     /// Check the status of the underlying SSH connection.
     pub async fn check(&self) -> Result<(), Error> {
         delegate!(&self.0, imp, { imp.check().await })
+    }
+
+    /// Get the SSH connection's control socket path.
+    pub fn ctl(&self) -> &Path {
+        delegate!(&self.0, imp, { imp.ctl() })
     }
 
     /// Constructs a new [`Command`] for launching the program at path `program` on the remote

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -33,6 +33,10 @@ impl Session {
         Ok(())
     }
 
+    pub(crate) fn ctl(&self) -> &Path {
+        &self.ctl
+    }
+
     pub(crate) fn raw_command<S: AsRef<OsStr>>(&self, program: S) -> Command {
         Command::new(self.ctl.clone(), program.as_ref().as_bytes().into())
     }

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -188,7 +188,7 @@ impl Session {
 impl Drop for Session {
     fn drop(&mut self) {
         // Keep tempdir alive until the connection is established
-        let _ctl = match self.tempdir.take() {
+        let _tempdir = match self.tempdir.take() {
             Some(tempdir) => tempdir,
             // return since close must have already been called.
             None => return,

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -12,20 +12,20 @@ use tempfile::TempDir;
 
 #[derive(Debug)]
 pub(crate) struct Session {
-    ctl: Option<TempDir>,
-    ctl_path: Box<Path>,
+    tempdir: Option<TempDir>,
+    ctl: Box<Path>,
     addr: Box<str>,
     master_log: Box<Path>,
 }
 
 impl Session {
-    pub(crate) fn new(ctl: TempDir, addr: &str) -> Self {
-        let log = ctl.path().join("log").into_boxed_path();
-        let ctl_path = ctl.path().join("master").into_boxed_path();
+    pub(crate) fn new(tempdir: TempDir, addr: &str) -> Self {
+        let log = tempdir.path().join("log").into_boxed_path();
+        let ctl = tempdir.path().join("master").into_boxed_path();
 
         Self {
-            ctl: Some(ctl),
-            ctl_path,
+            tempdir: Some(tempdir),
+            ctl,
             addr: addr.into(),
             master_log: log,
         }
@@ -35,7 +35,7 @@ impl Session {
         let mut cmd = std::process::Command::new("ssh");
         cmd.stdin(Stdio::null())
             .arg("-S")
-            .arg(&*self.ctl_path)
+            .arg(&*self.ctl)
             .arg("-o")
             .arg("BatchMode=yes")
             .args(args)
@@ -63,6 +63,10 @@ impl Session {
         } else {
             Ok(())
         }
+    }
+
+    pub(crate) fn ctl(&self) -> &Path {
+        &self.ctl
     }
 
     pub(crate) fn raw_command<S: AsRef<OsStr>>(&self, program: S) -> Command {
@@ -117,8 +121,8 @@ impl Session {
     pub(crate) async fn close(mut self) -> Result<(), Error> {
         let mut exit_cmd = self.new_cmd(&["-O", "exit"]);
 
-        // Take self.ctl so that drop would do nothing
-        let ctl = self.ctl.take().unwrap();
+        // Take self.tempdir so that drop would do nothing
+        let tempdir = self.tempdir.take().unwrap();
 
         let exit = exit_cmd.output().await.map_err(Error::Ssh)?;
 
@@ -148,7 +152,7 @@ impl Session {
             )));
         }
 
-        ctl.close().map_err(Error::Cleanup)?;
+        tempdir.close().map_err(Error::Cleanup)?;
 
         Ok(())
     }
@@ -184,8 +188,8 @@ impl Session {
 impl Drop for Session {
     fn drop(&mut self) {
         // Keep tempdir alive until the connection is established
-        let _ctl = match self.ctl.take() {
-            Some(ctl) => ctl,
+        let _ctl = match self.tempdir.take() {
+            Some(tempdir) => tempdir,
             // return since close must have already been called.
             None => return,
         };


### PR DESCRIPTION
In some situations, it's handy to have access to a SSH session's control
socket path. Therefore, expose it via a getter function.