### PR TITLE
Bump dep openssh-mux-client to v0.14.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ io-lifetimes = "0.5"
 once_cell = "1.8.0"
 dirs = "4.0.0"
 
-openssh-mux-client = { version = "0.14.3", optional = true }
+openssh-mux-client = { version = "0.14.4", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4.0"


### PR DESCRIPTION
tokio-io-utility used by openssh-mux-client v0.14.3 is yanked.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>