### PR TITLE
Improve local testing scripts

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           chmod 600 .test-key
-          ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new whoami
+          ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |
           eval $(ssh-agent)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,19 @@
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
   pull_request:
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
 name: coverage
 jobs:
   test:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
       - run: |
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
-          ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
+          ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |
           eval $(ssh-agent)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
       - run: |
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
-          ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
+          ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |
           eval $(ssh-agent)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           chmod 600 .test-key
+          mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -1,7 +1,19 @@
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
   pull_request:
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
 name: cargo hack
 jobs:
   check:

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           chmod 600 .test-key
+          mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           chmod 600 .test-key
-          ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new whoami
+          ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |
           eval $(ssh-agent)

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -1,7 +1,19 @@
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
   pull_request:
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
 name: With dependencies at minimal versions
 jobs:
   test:

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -31,7 +31,7 @@ jobs:
       - run: |
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
-          ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
+          ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |
           eval $(ssh-agent)

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,7 +1,19 @@
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
   pull_request:
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
 name: Minimum Supported Rust Version
 jobs:
   check:

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -1,7 +1,19 @@
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
   pull_request:
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
 name: cargo check
 jobs:
   os-check:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 name: shellcheck
 jobs:
-  os-check:
+  shellcheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+name: shellcheck
+jobs:
+  os-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: shellcheck
+        run: shellcheck *.sh

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,7 +1,19 @@
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
   pull_request:
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
 name: lint
 jobs:
   style:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,19 @@
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
   pull_request:
+    paths-ignore:
+      - 'build_doc.sh'
+      - 'check.sh'
+      - 'run_ci_tests.sh'
+      - 'start_sshd.sh'
+      - 'stop_sshd.sh'
 name: cargo test
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           chmod 600 .test-key
+          mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           chmod 600 .test-key
-          ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new whoami
+          ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |
           eval $(ssh-agent)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - run: |
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
-          ssh -i .test-key -v -p 2222 -l test-user openssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
+          ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |
           eval $(ssh-agent)

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/ci-target
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ repository = "https://github.com/openssh-rust/openssh.git"
 keywords = ["ssh","remote","openssh","orchestration"]
 categories = ["network-programming", "api-bindings"]
 
+exclude = ["ci-target", "*.sh"]
+
 [badges]
 azure-devops = { project = "jonhoo/jonhoo", pipeline = "openssh", build = "23" }
 codecov = { repository = "jonhoo/openssh-rs", branch = "master", service = "github" }

--- a/check.sh
+++ b/check.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash
+
+set -euxo pipefail
 
 cd "$(dirname "$(realpath "$0")")"
 

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+cd $(dirname `realpath $0`)
+
+cargo check --tests --all-features
+cargo clippy --all-features
+exec cargo test --all-features

--- a/check.sh
+++ b/check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-cd $(dirname `realpath $0`)
+cd "$(dirname "$(realpath "$0")")"
 
 cargo check --tests --all-features
 cargo clippy --all-features

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -34,7 +34,7 @@ trap cleanup EXIT
 echo Run tests
 rm -rf control-test config-file-test .ssh-connection*
 
-echo Remove all files in /tmp in the container
+echo "Remove all files in /tmp in the container"
 docker exec -it openssh bash -c 'rm -rf /tmp/*'
 
 echo Running integration test

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -4,6 +4,8 @@ set -euxo pipefail
 
 cd "$(dirname "$(realpath "$0")")"
 
+./start_sshd.sh
+
 export RUSTFLAGS='--cfg=ci'
 
 # Use a different target-dir since RUSTFLAGS='--cfg=ci' seems to

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -36,6 +36,10 @@ trap cleanup EXIT
 echo Run tests
 rm -rf control-test config-file-test .ssh-connection*
 
+# Sftp integration tests creates files and directories in /tmp.
+# Normally, these tests would remove any files and directories created in /tmp,
+# but in case they fail, these files will be left there and
+# interfere with the next integration test.
 echo "Remove all files in /tmp in the container"
 docker exec -it openssh bash -c 'rm -rf /tmp/*'
 

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -2,55 +2,44 @@
 
 cd $(dirname `realpath $0`)
 
-# Start the container
-export PUBLIC_KEY='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGzHvK2pKtSlZXP9tPYOOBb/xn0IiC9iLMS355AYUPC7'
-export DOCKER_MODS='linuxserver/mods:openssh-server-ssh-tunnel'
-
-name=openssh
-
-docker run \
-    --name $name \
-    --rm \
-    -d \
-    -p 127.0.0.1:2222:2222 \
-    -e 'USER_NAME=test-user' \
-    -e DOCKER_MODS \
-    -e PUBLIC_KEY \
-    linuxserver/openssh-server:amd64-latest
-
-function cleanup {
-    docker stop $name
-
-    # Revert modification to ~/.ssh/known_hosts
-    ssh-keygen -R "[127.0.0.1]:2222"
-
-    ssh-agent -k
-}
-trap cleanup EXIT
+./start_sshd.sh
 
 export RUSTFLAGS='--cfg=ci'
 
-cargo hack check --feature-powerset
+# Use a different target-dir since RUSTFLAGS='--cfg=ci' seems to
+# affect dependencies as well.
+#
+# Since IDEs usually do not set RUSTFLAGS='--cfg=ci', setting it
+# here would cause all the dependencies and openssh to be rebuilt.
+#
+# Thus it makes run_ci_tests.sh incrediably slow, and it also
+# affects IDEs checking, since now the IDEs also need to
+# rebuild the crate.
+CARGO_OPTS='--target-dir ci-target'
 
-cargo clippy --all-features
+cargo hack --feature-powerset check $CARGO_OPTS
+cargo clippy --all-features $CARGO_OPTS
 
 export HOSTNAME=127.0.0.1
-chmod 600 .test-key
-
-echo Waiting for sshd to be up
-while ! ssh -i .test-key -v -p 2222 -l test-user $HOSTNAME -o StrictHostKeyChecking=no whoami; do
-    sleep 3
-done
 
 echo Set up ssh agent
 eval $(ssh-agent)
 cat .test-key | ssh-add -
 
+function cleanup {
+    ssh-agent -k
+}
+trap cleanup EXIT
+
 echo Run tests
 rm -rf control-test config-file-test .ssh-connection*
 
+echo Remove all files in /tmp in the container
+docker exec -it openssh bash -c 'rm -rf /tmp/*'
+
 echo Running integration test
 cargo test \
+    $CARGO_OPTS \
     --all-features \
     --no-fail-fast \
     -- --test-threads=3 # Use test-threads=3 so that the output is readable

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -24,7 +24,7 @@ export HOSTNAME=127.0.0.1
 
 echo Set up ssh agent
 eval "$(ssh-agent)"
-cat .test-key | ssh-add -
+ssh-add - <.test-key
 
 function cleanup {
     ssh-agent -k

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -1,8 +1,8 @@
-#!/bin/bash -ex
+#!/bin/bash
 
-cd $(dirname `realpath $0`)
+set -euxo pipefail
 
-./start_sshd.sh
+cd "$(dirname "$(realpath "$0")")"
 
 export RUSTFLAGS='--cfg=ci'
 

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -36,13 +36,6 @@ trap cleanup EXIT
 echo Run tests
 rm -rf control-test config-file-test .ssh-connection*
 
-# Sftp integration tests creates files and directories in /tmp.
-# Normally, these tests would remove any files and directories created in /tmp,
-# but in case they fail, these files will be left there and
-# interfere with the next integration test.
-echo "Remove all files in /tmp in the container"
-docker exec -it openssh bash -c 'rm -rf /tmp/*'
-
 echo Running integration test
 cargo test \
     --all-features \

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -17,8 +17,8 @@ export RUSTFLAGS='--cfg=ci'
 # rebuild the crate.
 export CARGO_TARGET_DIR=ci-target
 
-cargo hack --feature-powerset check $CARGO_OPTS
-cargo clippy --all-features $CARGO_OPTS
+cargo hack --feature-powerset check
+cargo clippy --all-features
 
 export HOSTNAME=127.0.0.1
 
@@ -39,7 +39,6 @@ docker exec -it openssh bash -c 'rm -rf /tmp/*'
 
 echo Running integration test
 cargo test \
-    $CARGO_OPTS \
     --all-features \
     --no-fail-fast \
     -- --test-threads=3 # Use test-threads=3 so that the output is readable

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -15,7 +15,7 @@ export RUSTFLAGS='--cfg=ci'
 # Thus it makes run_ci_tests.sh incrediably slow, and it also
 # affects IDEs checking, since now the IDEs also need to
 # rebuild the crate.
-CARGO_OPTS='--target-dir ci-target'
+export CARGO_TARGET_DIR=ci-target
 
 cargo hack --feature-powerset check $CARGO_OPTS
 cargo clippy --all-features $CARGO_OPTS

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -23,7 +23,7 @@ cargo clippy --all-features
 export HOSTNAME=127.0.0.1
 
 echo Set up ssh agent
-eval $(ssh-agent)
+eval "$(ssh-agent)"
 cat .test-key | ssh-add -
 
 function cleanup {

--- a/start_sshd.sh
+++ b/start_sshd.sh
@@ -23,15 +23,12 @@ docker run \
 export HOSTNAME=127.0.0.1
 chmod 600 .test-key
 
-# Remove 127.0.0.1:2222 from known_hosts
-ssh-keygen -R "[127.0.0.1]:2222"
-rm -f ~/.ssh/known_hosts.old
+mkdir -p "$XDG_RUNTIME_DIR/openssh-rs/"
 
 echo Waiting for sshd to be up
-while ! ssh -i .test-key -v -p 2222 -l test-user $HOSTNAME -o StrictHostKeyChecking=no whoami; do
+while ! ssh -i .test-key -v -p 2222 -l test-user $HOSTNAME -o StrictHostKeyChecking=no -o UserKnownHostsFile="$XDG_RUNTIME_DIR/openssh-rs/known_hosts" whoami; do
     sleep 3
 done
 
-# Create sshd_started in /tmp/ so that it is auto removed on restart.
-mkdir -p "$XDG_RUNTIME_DIR/openssh-rs/"
+# Create sshd_started in runtime directory so that it is auto removed on restart.
 touch "$XDG_RUNTIME_DIR/openssh-rs/sshd_started"

--- a/start_sshd.sh
+++ b/start_sshd.sh
@@ -4,6 +4,8 @@ set -euxo pipefail
 
 cd "$(dirname "$(realpath "$0")")"
 
+[ -z ${XDG_RUNTIME_DIR+x} ] && export XDG_RUNTIME_DIR=/tmp
+
 [ -f "$XDG_RUNTIME_DIR/openssh-rs/sshd_started" ] && exit
 
 # Start the container

--- a/start_sshd.sh
+++ b/start_sshd.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -ex
+
+[ -f "$XDG_RUNTIME_DIR/openssh-rs/sshd_started" ] && exit
+
+cd $(dirname `realpath $0`)
+
+# Start the container
+export PUBLIC_KEY='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGzHvK2pKtSlZXP9tPYOOBb/xn0IiC9iLMS355AYUPC7'
+export DOCKER_MODS='linuxserver/mods:openssh-server-ssh-tunnel'
+
+docker run \
+    --name openssh \
+    --rm \
+    -d \
+    -p 127.0.0.1:2222:2222 \
+    -e 'USER_NAME=test-user' \
+    -e DOCKER_MODS \
+    -e PUBLIC_KEY \
+    linuxserver/openssh-server:amd64-latest
+
+export HOSTNAME=127.0.0.1
+chmod 600 .test-key
+
+# Remove 127.0.0.1:2222 from known_hosts
+ssh-keygen -R "[127.0.0.1]:2222"
+rm -f ~/.ssh/known_hosts.old
+
+echo Waiting for sshd to be up
+while ! ssh -i .test-key -v -p 2222 -l test-user $HOSTNAME -o StrictHostKeyChecking=no whoami; do
+    sleep 3
+done
+
+# Create sshd_started in /tmp/ so that it is auto removed on restart.
+mkdir -p "$XDG_RUNTIME_DIR/openssh-rs/"
+touch "$XDG_RUNTIME_DIR/openssh-rs/sshd_started"

--- a/start_sshd.sh
+++ b/start_sshd.sh
@@ -1,8 +1,10 @@
-#!/bin/bash -ex
+#!/bin/bash
+
+set -euxo pipefail
+
+cd "$(dirname "$(realpath "$0")")"
 
 [ -f "$XDG_RUNTIME_DIR/openssh-rs/sshd_started" ] && exit
-
-cd $(dirname `realpath $0`)
 
 # Start the container
 export PUBLIC_KEY='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGzHvK2pKtSlZXP9tPYOOBb/xn0IiC9iLMS355AYUPC7'

--- a/stop_sshd.sh
+++ b/stop_sshd.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+cd $(dirname `realpath $0`)
+
+rm "$XDG_RUNTIME_DIR/openssh-rs/sshd_started"
+
+docker stop openssh
+
+# Revert modification to ~/.ssh/known_hosts
+ssh-keygen -R "[127.0.0.1]:2222"

--- a/stop_sshd.sh
+++ b/stop_sshd.sh
@@ -4,6 +4,8 @@ set -euxo pipefail
 
 cd "$(dirname "$(realpath "$0")")"
 
+[ -z ${XDG_RUNTIME_DIR+x} ] && export XDG_RUNTIME_DIR=/tmp
+
 rm "$XDG_RUNTIME_DIR/openssh-rs/sshd_started"
 rm "$XDG_RUNTIME_DIR/openssh-rs/known_hosts"
 

--- a/stop_sshd.sh
+++ b/stop_sshd.sh
@@ -1,6 +1,8 @@
-#!/bin/bash -ex
+#!/bin/bash
 
-cd $(dirname `realpath $0`)
+set -euxo pipefail
+
+cd "$(dirname "$(realpath "$0")")"
 
 rm "$XDG_RUNTIME_DIR/openssh-rs/sshd_started"
 

--- a/stop_sshd.sh
+++ b/stop_sshd.sh
@@ -5,8 +5,6 @@ set -euxo pipefail
 cd "$(dirname "$(realpath "$0")")"
 
 rm "$XDG_RUNTIME_DIR/openssh-rs/sshd_started"
+rm "$XDG_RUNTIME_DIR/openssh-rs/known_hosts"
 
 docker stop openssh
-
-# Revert modification to ~/.ssh/known_hosts
-ssh-keygen -R "[127.0.0.1]:2222"

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -30,7 +30,9 @@ fn loopback() -> IpAddr {
 fn get_known_hosts_path() -> &'static Path {
     lazy_static! {
         static ref KNOWN_HOSTS_PATH: PathBuf = {
-            let mut path = env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from).unwrap();
+            let mut path = env::var_os("XDG_RUNTIME_DIR")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| "/tmp".into());
             path.push("openssh-rs/known_hosts");
             path
         };

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::io;
 use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 use tempfile::tempdir;
 
@@ -27,18 +27,12 @@ fn loopback() -> IpAddr {
     "127.0.0.1".parse().unwrap()
 }
 
-fn get_known_hosts_path() -> &'static Path {
-    lazy_static! {
-        static ref KNOWN_HOSTS_PATH: PathBuf = {
-            let mut path = env::var_os("XDG_RUNTIME_DIR")
-                .map(PathBuf::from)
-                .unwrap_or_else(|| "/tmp".into());
-            path.push("openssh-rs/known_hosts");
-            path
-        };
-    }
-
-    &KNOWN_HOSTS_PATH
+fn get_known_hosts_path() -> PathBuf {
+    let mut path = env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| "/tmp".into());
+    path.push("openssh-rs/known_hosts");
+    path
 }
 
 async fn session_builder_connect(mut builder: SessionBuilder, addr: &str) -> Vec<Session> {

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -1,9 +1,11 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::borrow::Cow;
+use std::env;
 use std::io;
 use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tempfile::tempdir;
 
@@ -25,8 +27,22 @@ fn loopback() -> IpAddr {
     "127.0.0.1".parse().unwrap()
 }
 
-async fn session_builder_connect(builder: SessionBuilder, addr: &str) -> Vec<Session> {
+fn get_known_hosts_path() -> &'static Path {
+    lazy_static! {
+        static ref KNOWN_HOSTS_PATH: PathBuf = {
+            let mut path = env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from).unwrap();
+            path.push("openssh-rs/known_hosts");
+            path
+        };
+    }
+
+    &KNOWN_HOSTS_PATH
+}
+
+async fn session_builder_connect(mut builder: SessionBuilder, addr: &str) -> Vec<Session> {
     let mut sessions = Vec::with_capacity(2);
+
+    builder.user_known_hosts_file(get_known_hosts_path());
 
     #[cfg(feature = "process-mux")]
     {
@@ -44,42 +60,42 @@ async fn session_builder_connect(builder: SessionBuilder, addr: &str) -> Vec<Ses
 async fn connects() -> Vec<Session> {
     let mut sessions = Vec::with_capacity(2);
 
+    let mut builder = SessionBuilder::default();
+
+    builder
+        .user_known_hosts_file(get_known_hosts_path())
+        .known_hosts_check(KnownHosts::Accept);
+
     #[cfg(feature = "process-mux")]
     {
-        sessions.push(Session::connect(&addr(), KnownHosts::Accept).await.unwrap());
+        sessions.push(builder.connect(&addr()).await.unwrap());
     }
 
     #[cfg(feature = "native-mux")]
     {
-        sessions.push(
-            Session::connect_mux(&addr(), KnownHosts::Accept)
-                .await
-                .unwrap(),
-        );
+        sessions.push(builder.connect_mux(&addr()).await.unwrap());
     }
 
     sessions
 }
 
 async fn connects_err(host: &str) -> Vec<Error> {
+    let mut builder = SessionBuilder::default();
+
+    builder
+        .user_known_hosts_file(get_known_hosts_path())
+        .known_hosts_check(KnownHosts::Accept);
+
     let mut errors = Vec::with_capacity(2);
 
     #[cfg(feature = "process-mux")]
     {
-        errors.push(
-            Session::connect(host, KnownHosts::Accept)
-                .await
-                .unwrap_err(),
-        );
+        errors.push(builder.connect(host).await.unwrap_err());
     }
 
     #[cfg(feature = "native-mux")]
     {
-        errors.push(
-            Session::connect_mux(host, KnownHosts::Accept)
-                .await
-                .unwrap_err(),
-        );
+        errors.push(builder.connect_mux(host).await.unwrap_err());
     }
 
     errors
@@ -233,18 +249,20 @@ async fn config_file() {
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]
 async fn terminate_on_drop() {
+    let mut builder = SessionBuilder::default();
+
+    builder
+        .user_known_hosts_file(get_known_hosts_path())
+        .known_hosts_check(KnownHosts::Add);
+
     #[cfg(feature = "process-mux")]
     {
-        drop(Session::connect(&addr(), KnownHosts::Add).await.unwrap());
+        drop(builder.connect(&addr()).await.unwrap());
     }
 
     #[cfg(feature = "native-mux")]
     {
-        drop(
-            Session::connect_mux(&addr(), KnownHosts::Add)
-                .await
-                .unwrap(),
-        );
+        drop(builder.connect_mux(&addr()).await.unwrap());
     }
     // NOTE: how do we test that it actually killed the master here?
 }
@@ -552,7 +570,8 @@ async fn connect_timeout() {
     use std::time::{Duration, Instant};
 
     let mut sb = SessionBuilder::default();
-    sb.connect_timeout(Duration::from_secs(1));
+    sb.connect_timeout(Duration::from_secs(1))
+        .user_known_hosts_file(get_known_hosts_path());
 
     let host = "192.0.0.8";
 


### PR DESCRIPTION
`run_ci_tests.sh` is refactored and new scripts `start_sshd.sh` and
`stop_sshd.sh` is created as a result.

Now, instead of starting a new sshd instance on every run to
`run_ci_tests.sh`, new sshd instance is started and shared among runs of
`run_ci_tests.sh` to speed up the testing cycle.

Another important improvements to `run_ci_tests.sh` is that now it uses
a different target directory to avoid rebuilding all dependencies.

Since IDEs usually do not set `RUSTFLAGS='--cfg=ci'`, `run_ci_tests.sh`
would usually rebuild all the dependencies and openssh.

This makes `run_ci_tests.sh` incrediably slow, and it also
affects IDEs checking, since now the IDEs also need to
rebuild the crate.

Changing the target directory to `ci-target` fixed this problem, and it
also has the new advantage that `run_ci_tests.sh` can be run
concurrently with the IDE checking and other `cargo` commands manually
run in terminal and the newly introduced `check.sh`.

`check.sh` is introduced to quickly check the syntax with flags
`--all-fatures` and run tests.

It is much faster than `run_ci_tests.sh`.

This PR is split from https://github.com/openssh-rust/openssh/pull/30 as it significantly improves the development experience.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>