### PR TITLE
Make `ChildStd{in, out, err}` opaque types

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -9,6 +9,11 @@ use crate::*;
 /// ## Added
 ///  - Added changelog
 ///  - Added [`SessionBuilder::compression`]
+///
+/// ## Changed
+///  - Make [`ChildStdin`] an opaque type.
+///  - Make [`ChildStdout`] an opaque type.
+///  - Make [`ChildStderr`] an opaque type.
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,3 @@
-use super::stdio::{ChildInputWrapper, ChildOutputWrapper};
 use super::RemoteChild;
 use super::Stdio;
 use super::{Error, Session};
@@ -236,18 +235,9 @@ impl<'s> Command<'s> {
                 let (imp, stdin, stdout, stderr) = imp.spawn().await?;
                 (
                     imp.into(),
-                    stdin
-                        .map(TryFrom::try_from)
-                        .transpose()?
-                        .map(|wrapper: ChildInputWrapper| wrapper.0),
-                    stdout
-                        .map(TryFrom::try_from)
-                        .transpose()?
-                        .map(|wrapper: ChildOutputWrapper| wrapper.0),
-                    stderr
-                        .map(TryFrom::try_from)
-                        .transpose()?
-                        .map(|wrapper: ChildOutputWrapper| wrapper.0),
+                    stdin.map(TryFrom::try_from).transpose()?,
+                    stdout.map(TryFrom::try_from).transpose()?,
+                    stderr.map(TryFrom::try_from).transpose()?,
                 )
             }),
         ))

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -4,8 +4,6 @@ use super::Error;
 use super::native_mux_impl;
 
 use io_lifetimes::OwnedFd;
-use std::convert::TryFrom;
-use std::convert::TryInto;
 use std::fs::File;
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -4,13 +4,15 @@ use super::Error;
 use super::native_mux_impl;
 
 use io_lifetimes::OwnedFd;
+use std::convert::TryFrom;
+use std::convert::TryInto;
 use std::fs::File;
 use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::pin::Pin;
 use std::process;
-
-use std::convert::TryFrom;
-use std::convert::TryInto;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 pub(crate) unsafe fn dup(raw_fd: RawFd) -> Result<OwnedFd, Error> {
     let res = libc::dup(raw_fd);
@@ -101,40 +103,44 @@ impl_from_for_stdio!(process::ChildStdin);
 impl_from_for_stdio!(process::ChildStdout);
 impl_from_for_stdio!(process::ChildStderr);
 
+impl_from_for_stdio!(ChildStdin);
+impl_from_for_stdio!(ChildStdout);
+impl_from_for_stdio!(ChildStderr);
+
 impl_from_for_stdio!(File);
 
 macro_rules! impl_try_from_tokio_process_child_for_stdio {
-    ($type:ident, $wrapper:ty) => {
+    ($type:ident) => {
         impl TryFrom<tokio::process::$type> for Stdio {
             type Error = Error;
 
             fn try_from(arg: tokio::process::$type) -> Result<Self, Self::Error> {
-                let wrapper: $wrapper = arg.try_into()?;
+                let wrapper: $type = arg.try_into()?;
                 Ok(wrapper.0.into())
             }
         }
     };
 }
 
-impl_try_from_tokio_process_child_for_stdio!(ChildStdin, ChildInputWrapper);
-impl_try_from_tokio_process_child_for_stdio!(ChildStdout, ChildOutputWrapper);
-impl_try_from_tokio_process_child_for_stdio!(ChildStderr, ChildOutputWrapper);
+impl_try_from_tokio_process_child_for_stdio!(ChildStdin);
+impl_try_from_tokio_process_child_for_stdio!(ChildStdout);
+impl_try_from_tokio_process_child_for_stdio!(ChildStderr);
 
 /// Input for the remote child.
-pub type ChildStdin = tokio_pipe::PipeWrite;
+#[derive(Debug)]
+pub struct ChildStdin(tokio_pipe::PipeWrite);
 
 /// Stdout for the remote child.
-pub type ChildStdout = tokio_pipe::PipeRead;
+#[derive(Debug)]
+pub struct ChildStdout(tokio_pipe::PipeRead);
 
 /// Stderr for the remote child.
-pub type ChildStderr = tokio_pipe::PipeRead;
-
-pub(crate) struct ChildInputWrapper(pub(crate) ChildStdin);
-pub(crate) struct ChildOutputWrapper(pub(crate) ChildStderr);
+#[derive(Debug)]
+pub struct ChildStderr(tokio_pipe::PipeRead);
 
 macro_rules! impl_from_impl_child_io {
-    (process, $type:ident, $wrapper:ty) => {
-        impl TryFrom<tokio::process::$type> for $wrapper {
+    (process, $type:ident, $inner:ty) => {
+        impl TryFrom<tokio::process::$type> for $type {
             type Error = Error;
 
             fn try_from(arg: tokio::process::$type) -> Result<Self, Self::Error> {
@@ -143,15 +149,15 @@ macro_rules! impl_from_impl_child_io {
                 // safety: arg.as_raw_fd() is guaranteed to return a valid fd.
                 let fd = unsafe { dup(fd) }?.into_raw_fd();
                 Ok(Self(
-                    $type::from_raw_fd_checked(fd).map_err(Error::ChildIo)?,
+                    <$inner>::from_raw_fd_checked(fd).map_err(Error::ChildIo)?,
                 ))
             }
         }
     };
 
-    (native_mux, $type:ident, $wrapper:ty) => {
+    (native_mux, $type:ident) => {
         #[cfg(feature = "native-mux")]
-        impl TryFrom<native_mux_impl::$type> for $wrapper {
+        impl TryFrom<native_mux_impl::$type> for $type {
             type Error = Error;
 
             fn try_from(arg: native_mux_impl::$type) -> Result<Self, Self::Error> {
@@ -161,9 +167,85 @@ macro_rules! impl_from_impl_child_io {
     };
 }
 
-impl_from_impl_child_io!(process, ChildStdin, ChildInputWrapper);
-impl_from_impl_child_io!(process, ChildStdout, ChildOutputWrapper);
-impl_from_impl_child_io!(process, ChildStderr, ChildOutputWrapper);
+impl_from_impl_child_io!(process, ChildStdin, tokio_pipe::PipeWrite);
+impl_from_impl_child_io!(process, ChildStdout, tokio_pipe::PipeRead);
+impl_from_impl_child_io!(process, ChildStderr, tokio_pipe::PipeRead);
 
-impl_from_impl_child_io!(native_mux, ChildStdin, ChildInputWrapper);
-impl_from_impl_child_io!(native_mux, ChildStdout, ChildOutputWrapper);
+impl_from_impl_child_io!(native_mux, ChildStdin);
+impl_from_impl_child_io!(native_mux, ChildStdout);
+impl_from_impl_child_io!(native_mux, ChildStderr);
+
+macro_rules! impl_child_stdio {
+    (AsRawFd, $type:ty) => {
+        impl AsRawFd for $type {
+            fn as_raw_fd(&self) -> RawFd {
+                self.0.as_raw_fd()
+            }
+        }
+    };
+
+    (IntoRawFd, $type:ty) => {
+        impl IntoRawFd for $type {
+            fn into_raw_fd(self) -> RawFd {
+                self.0.into_raw_fd()
+            }
+        }
+    };
+
+    (AsyncRead, $type:ty) => {
+        impl_child_stdio!(AsRawFd, $type);
+        impl_child_stdio!(IntoRawFd, $type);
+
+        impl AsyncRead for $type {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                buf: &mut ReadBuf<'_>,
+            ) -> Poll<io::Result<()>> {
+                Pin::new(&mut self.0).poll_read(cx, buf)
+            }
+        }
+    };
+
+    (AsyncWrite, $type: ty) => {
+        impl_child_stdio!(AsRawFd, $type);
+        impl_child_stdio!(IntoRawFd, $type);
+
+        impl AsyncWrite for $type {
+            fn poll_write(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                buf: &[u8],
+            ) -> Poll<io::Result<usize>> {
+                Pin::new(&mut self.0).poll_write(cx, buf)
+            }
+
+            fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+                Pin::new(&mut self.0).poll_flush(cx)
+            }
+
+            fn poll_shutdown(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+            ) -> Poll<io::Result<()>> {
+                Pin::new(&mut self.0).poll_shutdown(cx)
+            }
+
+            fn poll_write_vectored(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                bufs: &[io::IoSlice<'_>],
+            ) -> Poll<io::Result<usize>> {
+                Pin::new(&mut self.0).poll_write_vectored(cx, bufs)
+            }
+
+            fn is_write_vectored(&self) -> bool {
+                self.0.is_write_vectored()
+            }
+        }
+    };
+}
+
+impl_child_stdio!(AsyncWrite, ChildStdin);
+impl_child_stdio!(AsyncRead, ChildStdout);
+impl_child_stdio!(AsyncRead, ChildStderr);


### PR DESCRIPTION
For future Windows support.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>