### PR TITLE
Refactor unit tests in mod `builder` & `error`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -344,41 +344,46 @@ impl KnownHosts {
     }
 }
 
-#[test]
-fn resolve() {
-    let b = SessionBuilder::default();
-    let (b, d) = b.resolve("ssh://test-user@127.0.0.1:2222");
-    assert_eq!(b.port.as_deref(), Some("2222"));
-    assert_eq!(b.user.as_deref(), Some("test-user"));
-    assert_eq!(d, "127.0.0.1");
+#[cfg(test)]
+mod tests {
+    use super::SessionBuilder;
 
-    let b = SessionBuilder::default();
-    let (b, d) = b.resolve("ssh://test-user@opensshtest:2222");
-    assert_eq!(b.port.as_deref(), Some("2222"));
-    assert_eq!(b.user.as_deref(), Some("test-user"));
-    assert_eq!(d, "opensshtest");
+    #[test]
+    fn resolve() {
+        let b = SessionBuilder::default();
+        let (b, d) = b.resolve("ssh://test-user@127.0.0.1:2222");
+        assert_eq!(b.port.as_deref(), Some("2222"));
+        assert_eq!(b.user.as_deref(), Some("test-user"));
+        assert_eq!(d, "127.0.0.1");
 
-    let b = SessionBuilder::default();
-    let (b, d) = b.resolve("ssh://opensshtest:2222");
-    assert_eq!(b.port.as_deref(), Some("2222"));
-    assert_eq!(b.user.as_deref(), None);
-    assert_eq!(d, "opensshtest");
+        let b = SessionBuilder::default();
+        let (b, d) = b.resolve("ssh://test-user@opensshtest:2222");
+        assert_eq!(b.port.as_deref(), Some("2222"));
+        assert_eq!(b.user.as_deref(), Some("test-user"));
+        assert_eq!(d, "opensshtest");
 
-    let b = SessionBuilder::default();
-    let (b, d) = b.resolve("ssh://test-user@opensshtest");
-    assert_eq!(b.port.as_deref(), None);
-    assert_eq!(b.user.as_deref(), Some("test-user"));
-    assert_eq!(d, "opensshtest");
+        let b = SessionBuilder::default();
+        let (b, d) = b.resolve("ssh://opensshtest:2222");
+        assert_eq!(b.port.as_deref(), Some("2222"));
+        assert_eq!(b.user.as_deref(), None);
+        assert_eq!(d, "opensshtest");
 
-    let b = SessionBuilder::default();
-    let (b, d) = b.resolve("ssh://opensshtest");
-    assert_eq!(b.port.as_deref(), None);
-    assert_eq!(b.user.as_deref(), None);
-    assert_eq!(d, "opensshtest");
+        let b = SessionBuilder::default();
+        let (b, d) = b.resolve("ssh://test-user@opensshtest");
+        assert_eq!(b.port.as_deref(), None);
+        assert_eq!(b.user.as_deref(), Some("test-user"));
+        assert_eq!(d, "opensshtest");
 
-    let b = SessionBuilder::default();
-    let (b, d) = b.resolve("opensshtest");
-    assert_eq!(b.port.as_deref(), None);
-    assert_eq!(b.user.as_deref(), None);
-    assert_eq!(d, "opensshtest");
+        let b = SessionBuilder::default();
+        let (b, d) = b.resolve("ssh://opensshtest");
+        assert_eq!(b.port.as_deref(), None);
+        assert_eq!(b.user.as_deref(), None);
+        assert_eq!(d, "opensshtest");
+
+        let b = SessionBuilder::default();
+        let (b, d) = b.resolve("opensshtest");
+        assert_eq!(b.port.as_deref(), None);
+        assert_eq!(b.user.as_deref(), None);
+        assert_eq!(d, "opensshtest");
+    }
 }


### PR DESCRIPTION
Wrap them in a `tests` module, which is only compiled in testing and
ignored in release.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>