### PR TITLE
Fix child io types: Avoid exposing impl details

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -1,9 +1,9 @@
+use super::stdio::TryFromChildIo;
 use super::RemoteChild;
 use super::Stdio;
 use super::{Error, Session};
 
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::ffi::OsStr;
 use std::process;
 
@@ -235,9 +235,9 @@ impl<'s> Command<'s> {
                 let (imp, stdin, stdout, stderr) = imp.spawn().await?;
                 (
                     imp.into(),
-                    stdin.map(TryFrom::try_from).transpose()?,
-                    stdout.map(TryFrom::try_from).transpose()?,
-                    stderr.map(TryFrom::try_from).transpose()?,
+                    stdin.map(TryFromChildIo::try_from).transpose()?,
+                    stdout.map(TryFromChildIo::try_from).transpose()?,
+                    stderr.map(TryFromChildIo::try_from).transpose()?,
                 )
             }),
         ))

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -152,9 +152,9 @@ macro_rules! impl_from_impl_child_io {
 
                 // safety: arg.as_raw_fd() is guaranteed to return a valid fd.
                 let fd = unsafe { dup(fd) }?.into_raw_fd();
-                Ok(Self(
-                    <$inner>::from_raw_fd_checked(fd).map_err(Error::ChildIo)?,
-                ))
+                <$inner>::from_raw_fd_checked(fd)
+                    .map(Self)
+                    .map_err(Error::ChildIo)
             }
         }
     };

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -113,7 +113,7 @@ macro_rules! impl_try_from_tokio_process_child_for_stdio {
             type Error = Error;
 
             fn try_from(arg: tokio::process::$type) -> Result<Self, Self::Error> {
-                let wrapper: $type = arg.try_into()?;
+                let wrapper: $type = TryFromChildIo::try_from(arg)?;
                 Ok(wrapper.0.into())
             }
         }
@@ -136,9 +136,15 @@ pub struct ChildStdout(tokio_pipe::PipeRead);
 #[derive(Debug)]
 pub struct ChildStderr(tokio_pipe::PipeRead);
 
+pub(crate) trait TryFromChildIo<T>: Sized {
+    type Error;
+
+    fn try_from(arg: T) -> Result<Self, Self::Error>;
+}
+
 macro_rules! impl_from_impl_child_io {
     (process, $type:ident, $inner:ty) => {
-        impl TryFrom<tokio::process::$type> for $type {
+        impl TryFromChildIo<tokio::process::$type> for $type {
             type Error = Error;
 
             fn try_from(arg: tokio::process::$type) -> Result<Self, Self::Error> {
@@ -155,7 +161,7 @@ macro_rules! impl_from_impl_child_io {
 
     (native_mux, $type:ident) => {
         #[cfg(feature = "native-mux")]
-        impl TryFrom<native_mux_impl::$type> for $type {
+        impl TryFromChildIo<native_mux_impl::$type> for $type {
             type Error = Error;
 
             fn try_from(arg: native_mux_impl::$type) -> Result<Self, Self::Error> {


### PR DESCRIPTION
Implementing `TryFrom<tokio::process::ChildStd*>` for `ChildStd*`
exposes the implementation details, and permits the caller to construct
a `ChildStd*`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>