### PR TITLE
Prepare support for windows

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -127,6 +127,8 @@ impl SessionBuilder {
     /// be created.
     ///
     /// If not set, `./` will be used (the current directory).
+    #[cfg(not(windows))]
+    #[cfg_attr(docsrs, doc(cfg(not(windows))))]
     pub fn control_directory(&mut self, p: impl AsRef<Path>) -> &mut Self {
         self.control_dir = Some(p.as_ref().to_path_buf());
         self

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -3,6 +3,9 @@ use crate::*;
 
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
 #[doc(hidden)]
+/// ## Changed
+///  - Make [`Session::check`] available only on unix.
+///  - Make [`Socket::UnixSocket`] available only on unix.
 pub mod unreleased {}
 
 /// ## Fixed

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -6,6 +6,7 @@ use crate::*;
 /// ## Changed
 ///  - Make [`Session::check`] available only on unix.
 ///  - Make [`Socket::UnixSocket`] available only on unix.
+///  - Make [`SessionBuilder::control_socket`] available only on unix.
 pub mod unreleased {}
 
 /// ## Fixed

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -6,7 +6,7 @@ use crate::*;
 /// ## Changed
 ///  - Make [`Session::check`] available only on unix.
 ///  - Make [`Socket::UnixSocket`] available only on unix.
-///  - Make [`SessionBuilder::control_socket`] available only on unix.
+///  - Make [`SessionBuilder::control_directory`] available only on unix.
 pub mod unreleased {}
 
 /// ## Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,8 @@ impl Session {
     }
 
     /// Check the status of the underlying SSH connection.
+    #[cfg(not(windows))]
+    #[cfg_attr(docsrs, doc(cfg(not(windows))))]
     pub async fn check(&self) -> Result<(), Error> {
         delegate!(&self.0, imp, { imp.check().await })
     }

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -36,6 +36,8 @@ impl From<ForwardType> for native_mux_impl::ForwardType {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Socket<'a> {
     /// Unix socket.
+    #[cfg(not(windows))]
+    #[cfg_attr(docsrs, doc(cfg(not(windows))))]
     UnixSocket {
         /// Filesystem path
         path: Cow<'a, Path>,
@@ -59,6 +61,7 @@ impl Socket<'_> {
     #[cfg(feature = "process-mux")]
     pub(crate) fn as_os_str(&self) -> Cow<'_, OsStr> {
         match self {
+            #[cfg(not(windows))]
             Socket::UnixSocket { path } => Cow::Borrowed(path.as_os_str()),
             Socket::TcpSocket(socket) => Cow::Owned(format!("{}", socket).into()),
         }
@@ -71,6 +74,7 @@ impl<'a> From<Socket<'a>> for native_mux_impl::Socket<'a> {
         use native_mux_impl::Socket::*;
 
         match socket {
+            #[cfg(not(windows))]
             Socket::UnixSocket { path } => UnixSocket { path },
             Socket::TcpSocket(socket) => TcpSocket {
                 port: socket.port() as u32,
@@ -83,6 +87,7 @@ impl<'a> From<Socket<'a>> for native_mux_impl::Socket<'a> {
 impl<'a> fmt::Display for Socket<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            #[cfg(not(windows))]
             Socket::UnixSocket { path } => {
                 write!(f, "{}", path.to_string_lossy())
             }

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -36,8 +36,8 @@ impl From<ForwardType> for native_mux_impl::ForwardType {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Socket<'a> {
     /// Unix socket.
-    #[cfg(not(windows))]
-    #[cfg_attr(docsrs, doc(cfg(not(windows))))]
+    #[cfg(unix)]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
     UnixSocket {
         /// Filesystem path
         path: Cow<'a, Path>,
@@ -61,7 +61,7 @@ impl Socket<'_> {
     #[cfg(feature = "process-mux")]
     pub(crate) fn as_os_str(&self) -> Cow<'_, OsStr> {
         match self {
-            #[cfg(not(windows))]
+            #[cfg(unix)]
             Socket::UnixSocket { path } => Cow::Borrowed(path.as_os_str()),
             Socket::TcpSocket(socket) => Cow::Owned(format!("{}", socket).into()),
         }
@@ -74,7 +74,7 @@ impl<'a> From<Socket<'a>> for native_mux_impl::Socket<'a> {
         use native_mux_impl::Socket::*;
 
         match socket {
-            #[cfg(not(windows))]
+            #[cfg(unix)]
             Socket::UnixSocket { path } => UnixSocket { path },
             Socket::TcpSocket(socket) => TcpSocket {
                 port: socket.port() as u32,
@@ -87,7 +87,7 @@ impl<'a> From<Socket<'a>> for native_mux_impl::Socket<'a> {
 impl<'a> fmt::Display for Socket<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            #[cfg(not(windows))]
+            #[cfg(unix)]
             Socket::UnixSocket { path } => {
                 write!(f, "{}", path.to_string_lossy())
             }


### PR DESCRIPTION
Make
 - `Session::check`
 - `Socket::UnixSocket`
 - `SessionBuilder::control_socket`

only available on unix.