### PR TITLE
PR for bumping dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ io-lifetimes = "0.6"
 once_cell = "1.10.0"
 dirs = "4.0.0"
 
-openssh-mux-client = { version = "0.14.4", optional = true }
+openssh-mux-client = { version = "0.15.0", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,15 +36,15 @@ process-mux = []
 native-mux = ["openssh-mux-client"]
 
 [dependencies]
-tempfile = "3.3.0"
+tempfile = "3.1.0"
 shell-escape = "0.1.5"
 tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
-tokio-pipe = "0.2.11"
+tokio-pipe = "0.2.8"
 
-libc = "0.2.121"
+libc = "0.2.112"
 io-lifetimes = "0.6"
 
-once_cell = "1.10.0"
+once_cell = "1.8.0"
 dirs = "4.0.0"
 
 openssh-mux-client = { version = "0.15.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tokio-pipe = "0.2.8"
 libc = "0.2.112"
 io-lifetimes = "0.5"
 
-once_cell = "1.8.0"
+once_cell = "1.10.0"
 dirs = "4.0.0"
 
 openssh-mux-client = { version = "0.14.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh"
-version = "0.9.0"
+version = "0.9.0-rc.3"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2021"
 rust-version = "1.56.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
 tokio-pipe = "0.2.8"
 
 libc = "0.2.112"
-io-lifetimes = "0.5"
+io-lifetimes = "0.6"
 
 once_cell = "1.10.0"
 dirs = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh"
-version = "0.9.0-rc.3"
+version = "0.9.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2021"
 rust-version = "1.56.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ shell-escape = "0.1.5"
 tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
 tokio-pipe = "0.2.11"
 
-libc = "0.2.112"
+libc = "0.2.121"
 io-lifetimes = "0.6"
 
 once_cell = "1.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ process-mux = []
 native-mux = ["openssh-mux-client"]
 
 [dependencies]
-tempfile = "3.1.0"
+tempfile = "3.3.0"
 shell-escape = "0.1.5"
 tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
 tokio-pipe = "0.2.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ native-mux = ["openssh-mux-client"]
 tempfile = "3.1.0"
 shell-escape = "0.1.5"
 tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
-tokio-pipe = "0.2.8"
+tokio-pipe = "0.2.11"
 
 libc = "0.2.112"
 io-lifetimes = "0.6"

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -2,7 +2,9 @@
 use crate::*;
 
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
-///
+#[doc(hidden)]
+pub mod unreleased {}
+
 /// ## Fixed
 ///  - Remove accidentally exposed `TryFrom<tokio::process::ChildStdin`
 ///    implementation for [`ChildStdin`].
@@ -16,12 +18,12 @@ use crate::*;
 ///    implementation for [`ChildStderr`].
 ///  - Remove accidentally exposed `TryFrom<tokio_pipe::PipeRead>`
 ///    implementation for [`ChildStderr`].
-#[doc(hidden)]
+///
 /// ## Changed
 ///  - Make [`Session::check`] available only on unix.
 ///  - Make [`Socket::UnixSocket`] available only on unix.
 ///  - Make [`SessionBuilder::control_directory`] available only on unix.
-pub mod unreleased {}
+pub mod v0_9_0 {}
 
 /// ## Fixed
 ///  - Fixed changelog entry for rc2 not being visible

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -2,9 +2,7 @@
 use crate::*;
 
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
-#[doc(hidden)]
-pub mod unreleased {}
-
+///
 /// ## Fixed
 ///  - Remove accidentally exposed `TryFrom<tokio::process::ChildStdin`
 ///    implementation for [`ChildStdin`].
@@ -23,7 +21,8 @@ pub mod unreleased {}
 ///  - Make [`Session::check`] available only on unix.
 ///  - Make [`Socket::UnixSocket`] available only on unix.
 ///  - Make [`SessionBuilder::control_directory`] available only on unix.
-pub mod v0_9_0 {}
+#[doc(hidden)]
+pub mod unreleased {}
 
 /// ## Fixed
 ///  - Fixed changelog entry for rc2 not being visible

--- a/src/command.rs
+++ b/src/command.rs
@@ -92,8 +92,6 @@ pub struct Command<'s> {
 
 impl<'s> Command<'s> {
     pub(crate) fn new(session: &'s super::Session, imp: CommandImp) -> Self {
-        // All implementations of Command initializes stdin, stdout and stderr
-        // to Stdio::inherit()
         Self {
             session,
             imp,


### PR DESCRIPTION
Fixed #49 .

This PR bumps dependencies, update comment and bump the version of the crate to `v0.9.0`.