### PR TITLE
Fix `no_route` on macos

### DIFF
--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -29,6 +29,19 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: actions/checkout@v2
+      - name: Create Cargo.lock
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-os-check-v0
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -32,5 +32,5 @@ jobs:
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: test
           args: --all-features --all-targets

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -33,15 +33,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: update
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-os-check-v0
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -14,7 +14,7 @@ on:
       - 'run_ci_tests.sh'
       - 'start_sshd.sh'
       - 'stop_sshd.sh'
-name: cargo check
+name: os check
 jobs:
   os-check:
     runs-on: ${{ matrix.os }}
@@ -29,7 +29,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: actions/checkout@v2
-      - name: cargo check
+      - name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -76,8 +76,10 @@ async fn connects() -> Vec<Session> {
 }
 
 async fn connects_err(host: &str) -> Vec<Error> {
-    let mut builder = SessionBuilder::default();
+    session_builder_connects_err(host, SessionBuilder::default()).await
+}
 
+async fn session_builder_connects_err(host: &str, mut builder: SessionBuilder) -> Vec<Error> {
     builder
         .user_known_hosts_file(get_known_hosts_path())
         .known_hosts_check(KnownHosts::Accept);
@@ -669,11 +671,15 @@ async fn cannot_resolve() {
 
 #[tokio::test]
 async fn no_route() {
-    for err in connects_err("255.255.255.255").await {
+    let mut builder = SessionBuilder::default();
+
+    builder.connect_timeout(Duration::from_nanos(0));
+
+    for err in session_builder_connects_err("192.0.2.1", builder).await {
         match err {
             Error::Connect(e) => {
                 eprintln!("{:?}", e);
-                assert_eq!(e.kind(), io::ErrorKind::Other);
+                assert_eq!(e.kind(), io::ErrorKind::TimedOut);
             }
             e => unreachable!("{:?}", e),
         }

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -673,7 +673,7 @@ async fn cannot_resolve() {
 async fn no_route() {
     let mut builder = SessionBuilder::default();
 
-    builder.connect_timeout(Duration::from_nanos(0));
+    builder.connect_timeout(Duration::from_secs(1));
 
     for err in session_builder_connects_err("192.0.2.1", builder).await {
         match err {


### PR DESCRIPTION
Fixed #63 using "192.0.2.1" plus timeout of 0ns.

The only drawback is that now `no_route` takes much longer to run.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>