### PR TITLE
Speedup ci by actions/cache@v3 and taiki-e/install-action 

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -24,6 +24,19 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: actions/checkout@v2
+      - name: Create Cargo.lock
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-cargo-hack-v0
       - uses: taiki-e/install-action@cargo-hack
       - name: cargo hack
         uses: actions-rs/cargo@v1

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -24,12 +24,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - uses: actions/checkout@v2
-      - name: Install cargo-hack
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-hack
-          version: latest
-          use-tool-cache: true
+      - uses: taiki-e/install-action@cargo-hack
       - name: cargo hack
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -45,6 +45,15 @@ jobs:
           command: update
           toolchain: nightly
           args: -Zminimal-versions
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-with-dep-at-min-ver-v0
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -25,6 +25,19 @@ jobs:
           toolchain: 1.56.1
           override: true
       - uses: actions/checkout@v2
+      - name: Create Cargo.lock
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-msrv-v0
       - name: cargo +1.56.1 check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,19 @@ jobs:
           echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV
           cat .test-key | ssh-add -
         name: Set up ssh-agent
+      - name: Create Cargo.lock
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.lock') }}-test-v0
       - name: cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/build_doc.sh
+++ b/build_doc.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 export RUSTDOCFLAGS="--cfg docsrs"
-exec cargo +nightly doc --all-features
+exec cargo +nightly doc --all-features --no-deps


### PR DESCRIPTION
 - [Install cargo-hack using taiki-e/install-action](https://github.com/openssh-rust/openssh/commit/b74d868e294d6150bc9909f02e3a62218c3c5d56)
 - Speedup `minimal.yml`, `features.yml`, `msrv.yml` and `test.yml` using `actions/cache@v3`
 - [Speedup build_doc.sh: Avoid building doc of deps](https://github.com/openssh-rust/openssh/commit/25b1cd9ab4dad6589e9e29ccb5dcaca83cbbc7e9)

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>