### PR TITLE
Feature/resume

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - run: |
           # Wait for startup of openssh-server
-          sleep 15
+          timeout 15 ./wait_for_sshd_start_up.sh
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user localhost -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - run: |
           # Wait for startup of openssh-server
-          sleep 30
+          sleep 15
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user localhost -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -29,12 +29,13 @@ jobs:
           toolchain: stable
       - uses: actions/checkout@v2
       - run: |
+          # Wait for startup of openssh-server
+          sleep 15
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |
-          sleep 30
           eval $(ssh-agent)
           echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
           echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           # Wait for startup of openssh-server
-          sleep 15
+          timeout 15 ./wait_for_sshd_start_up.sh
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -34,6 +34,7 @@ jobs:
           ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami
         name: Test ssh connectivity
       - run: |
+          sleep 30
           eval $(ssh-agent)
           echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> $GITHUB_ENV
           echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -55,4 +55,4 @@ jobs:
           command: doc
           args: --no-deps --all-features
         env:
-          RUSTDOCFLAGS: --cfg docsrs
+          RUSTDOCFLAGS: --cfg docsrs -Dwarnings

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -55,4 +55,4 @@ jobs:
           command: doc
           args: --no-deps --all-features
         env:
-          RUSTDOCFLAGS: --cfg docsrs -Dwarnings
+          RUSTDOCFLAGS: --cfg docsrs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v2
       - run: |
-          sleep 30
+          # Wait for startup of openssh-server
+          sleep 15
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           # Wait for startup of openssh-server
+          timeout 15 ./wait_for_sshd_start_up.sh
           sleep 15
           chmod 600 .test-key
           mkdir /tmp/openssh-rs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
       - run: |
           # Wait for startup of openssh-server
           timeout 15 ./wait_for_sshd_start_up.sh
-          sleep 15
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - uses: actions/checkout@v2
       - run: |
+          sleep 30
           chmod 600 .test-key
           mkdir /tmp/openssh-rs
           ssh -i .test-key -v -p 2222 -l test-user 127.0.0.1 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/openssh-rs/known_hosts whoami

--- a/run_ci_tests.sh
+++ b/run_ci_tests.sh
@@ -41,3 +41,5 @@ cargo test \
     --all-features \
     --no-fail-fast \
     -- --test-threads=3 # Use test-threads=3 so that the output is readable
+
+rm -r .ssh-connection*

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -7,6 +7,7 @@ use crate::*;
 ///  - [`Session::resume`]
 ///  - [`Session::resume_mux`]
 ///  - [`Session::leak`]
+///  - [`Session::force_terminate`]
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -2,6 +2,11 @@
 use crate::*;
 
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
+///
+/// ## Added
+///  - [`Session::resume`]
+///  - [`Session::resume_mux`]
+///  - [`Session::leak`]
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -87,8 +87,7 @@ impl Session {
         Ok(())
     }
 
-    /// Return ctl, master_log
-    pub(crate) fn leak(mut self) -> (Box<Path>, Option<Box<Path>>) {
+    pub(crate) fn detach(mut self) -> (Box<Path>, Option<Box<Path>>) {
         (
             self.ctl.clone(),
             self.tempdir.take().map(TempDir::into_path).map(|mut path| {

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -76,6 +76,11 @@ impl Session {
 
         Ok(())
     }
+
+    pub(crate) fn leak(mut self) -> Box<Path> {
+        self.tempdir.take().unwrap().into_path();
+        self.ctl.clone()
+    }
 }
 
 impl Drop for Session {

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -78,7 +78,7 @@ impl Session {
     }
 
     pub(crate) fn leak(mut self) -> Box<Path> {
-        self.tempdir.take().unwrap().into_path();
+        self.tempdir.take().map(TempDir::into_path);
         self.ctl.clone()
     }
 }

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -99,7 +99,7 @@ impl Session {
     }
 
     /// Forced termination, ignores value of `tempdir`
-    pub(crate) async fn terminate(self) -> Result<(), Error> {
+    pub(crate) async fn force_terminate(self) -> Result<(), Error> {
         if self.tempdir.is_some() {
             self.close().await
         } else {

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -99,7 +99,7 @@ impl Session {
     }
 
     /// Forced termination, ignores value of `tempdir`
-    pub(crate) async fn terminate(mut self) -> Result<(), Error> {
+    pub(crate) async fn terminate(self) -> Result<(), Error> {
         if self.tempdir.is_some() {
             self.close().await
         } else {

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -82,6 +82,8 @@ impl Session {
             self.close_impl().await?;
 
             tempdir.close().map_err(Error::Cleanup)?;
+        } else {
+            self.close_impl().await?;
         }
 
         Ok(())
@@ -95,17 +97,6 @@ impl Session {
                 path.into_boxed_path()
             }),
         )
-    }
-
-    /// Forced termination, ignores value of `tempdir`
-    pub(crate) async fn force_terminate(self) -> Result<(), Error> {
-        if self.tempdir.is_some() {
-            self.close().await
-        } else {
-            self.close_impl().await?;
-
-            Ok(())
-        }
     }
 }
 

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -65,14 +65,14 @@ impl Session {
 
     pub(crate) async fn close(mut self) -> Result<(), Error> {
         // This also set self.tempdir to None so that Drop::drop would do nothing.
-        let tempdir = self.tempdir.take().unwrap();
+        if let Some(tempdir) = self.tempdir.take() {
+            Connection::connect(&self.ctl)
+                .await?
+                .request_stop_listening()
+                .await?;
 
-        Connection::connect(&self.ctl)
-            .await?
-            .request_stop_listening()
-            .await?;
-
-        tempdir.close().map_err(Error::Cleanup)?;
+            tempdir.close().map_err(Error::Cleanup)?;
+        }
 
         Ok(())
     }

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -24,6 +24,10 @@ impl Session {
         }
     }
 
+    pub(crate) fn resume(ctl: Box<Path>, _master_log: Option<Box<Path>>) -> Self {
+        Self { tempdir: None, ctl }
+    }
+
     pub(crate) async fn check(&self) -> Result<(), Error> {
         Connection::connect(&self.ctl)
             .await?

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -77,9 +77,15 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) fn leak(mut self) -> Box<Path> {
-        self.tempdir.take().map(TempDir::into_path);
-        self.ctl.clone()
+    /// Return ctl, master_log
+    pub(crate) fn leak(mut self) -> (Box<Path>, Option<Box<Path>>) {
+        (
+            self.ctl.clone(),
+            self.tempdir.take().map(TempDir::into_path).map(|mut path| {
+                path.push("log");
+                path.into_boxed_path()
+            }),
+        )
     }
 }
 

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -172,7 +172,7 @@ impl Session {
     /// Return ctl, master_log
     pub(crate) fn leak(mut self) -> (Box<Path>, Option<Box<Path>>) {
         self.tempdir.take().map(TempDir::into_path);
-        (self.ctl.clone(), self.master_log.clone())
+        (self.ctl.clone(), self.master_log.take())
     }
 
     fn discover_master_error(&self) -> Option<Error> {

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -131,40 +131,40 @@ impl Session {
     }
 
     pub(crate) async fn close(mut self) -> Result<(), Error> {
-        let mut exit_cmd = self.new_cmd(&["-O", "exit"]);
-
         // Take self.tempdir so that drop would do nothing
-        let tempdir = self.tempdir.take().unwrap();
+        if let Some(tempdir) = self.tempdir.take() {
+            let mut exit_cmd = self.new_cmd(&["-O", "exit"]);
 
-        let exit = exit_cmd.output().await.map_err(Error::Ssh)?;
+            let exit = exit_cmd.output().await.map_err(Error::Ssh)?;
 
-        if let Some(master_error) = self.discover_master_error() {
-            return Err(master_error);
+            if let Some(master_error) = self.discover_master_error() {
+                return Err(master_error);
+            }
+
+            // let's get this case straight:
+            // we tried to tell the master to exit.
+            // the -o exit command failed.
+            // the master exited, but did not produce an error.
+            // what could cause that?
+            //
+            // If the remote sshd process is accidentally killed, then the local
+            // ssh multiplex server would exit without anything printed to the log,
+            // and the -o exit command failed to connect to the multiplex server.
+            //
+            // Check `broken_connection` test in `tests/openssh.rs` for an example
+            // of this scenario.
+            if !exit.status.success() {
+                let exit_err = String::from_utf8_lossy(&exit.stderr);
+                let err = exit_err.trim();
+
+                return Err(Error::Ssh(io::Error::new(
+                    io::ErrorKind::ConnectionAborted,
+                    err,
+                )));
+            }
+
+            tempdir.close().map_err(Error::Cleanup)?;
         }
-
-        // let's get this case straight:
-        // we tried to tell the master to exit.
-        // the -o exit command failed.
-        // the master exited, but did not produce an error.
-        // what could cause that?
-        //
-        // If the remote sshd process is accidentally killed, then the local
-        // ssh multiplex server would exit without anything printed to the log,
-        // and the -o exit command failed to connect to the multiplex server.
-        //
-        // Check `broken_connection` test in `tests/openssh.rs` for an example
-        // of this scenario.
-        if !exit.status.success() {
-            let exit_err = String::from_utf8_lossy(&exit.stderr);
-            let err = exit_err.trim();
-
-            return Err(Error::Ssh(io::Error::new(
-                io::ErrorKind::ConnectionAborted,
-                err,
-            )));
-        }
-
-        tempdir.close().map_err(Error::Cleanup)?;
 
         Ok(())
     }

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -195,6 +195,17 @@ impl Session {
         (self.ctl.clone(), self.master_log.take())
     }
 
+    /// Forced termination, ignores value of `tempdir`
+    pub(crate) async fn terminate(self) -> Result<(), Error> {
+        if self.tempdir.is_some() {
+            self.close().await
+        } else {
+            self.close_impl().await?;
+
+            Ok(())
+        }
+    }
+
     fn discover_master_error(&self) -> Option<Error> {
         let err = match fs::read_to_string(self.master_log.as_ref()?) {
             Ok(err) => err,

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -169,6 +169,11 @@ impl Session {
         Ok(())
     }
 
+    pub(crate) fn leak(mut self) -> Box<Path> {
+        self.tempdir.take().unwrap().into_path();
+        self.ctl.clone()
+    }
+
     fn discover_master_error(&self) -> Option<Error> {
         let err = match fs::read_to_string(&self.master_log) {
             Ok(err) => err,

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -171,7 +171,7 @@ impl Session {
 
     /// Return ctl, master_log
     pub(crate) fn leak(mut self) -> (Box<Path>, Option<Box<Path>>) {
-        self.tempdir.take().unwrap().into_path();
+        self.tempdir.take().map(TempDir::into_path);
         (self.ctl.clone(), self.master_log.clone())
     }
 

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -15,7 +15,7 @@ pub(crate) struct Session {
     tempdir: Option<TempDir>,
     ctl: Box<Path>,
     addr: Box<str>,
-    master_log: Box<Path>,
+    master_log: Option<Box<Path>>,
 }
 
 impl Session {
@@ -27,7 +27,7 @@ impl Session {
             tempdir: Some(tempdir),
             ctl,
             addr: addr.into(),
-            master_log: log,
+            master_log: Some(log),
         }
     }
 
@@ -175,7 +175,7 @@ impl Session {
     }
 
     fn discover_master_error(&self) -> Option<Error> {
-        let err = match fs::read_to_string(&self.master_log) {
+        let err = match fs::read_to_string(self.master_log.as_ref()?) {
             Ok(err) => err,
             Err(e) => return Some(Error::Master(e)),
         };

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -196,7 +196,7 @@ impl Session {
     }
 
     /// Forced termination, ignores value of `tempdir`
-    pub(crate) async fn terminate(self) -> Result<(), Error> {
+    pub(crate) async fn force_terminate(self) -> Result<(), Error> {
         if self.tempdir.is_some() {
             self.close().await
         } else {

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -189,8 +189,7 @@ impl Session {
         Ok(())
     }
 
-    /// Return ctl, master_log
-    pub(crate) fn leak(mut self) -> (Box<Path>, Option<Box<Path>>) {
+    pub(crate) fn detach(mut self) -> (Box<Path>, Option<Box<Path>>) {
         self.tempdir.take().map(TempDir::into_path);
         (self.ctl.clone(), self.master_log.take())
     }

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -184,6 +184,8 @@ impl Session {
             self.close_impl().await?;
 
             tempdir.close().map_err(Error::Cleanup)?;
+        } else {
+            self.close_impl().await?;
         }
 
         Ok(())
@@ -192,17 +194,6 @@ impl Session {
     pub(crate) fn detach(mut self) -> (Box<Path>, Option<Box<Path>>) {
         self.tempdir.take().map(TempDir::into_path);
         (self.ctl.clone(), self.master_log.take())
-    }
-
-    /// Forced termination, ignores value of `tempdir`
-    pub(crate) async fn force_terminate(self) -> Result<(), Error> {
-        if self.tempdir.is_some() {
-            self.close().await
-        } else {
-            self.close_impl().await?;
-
-            Ok(())
-        }
     }
 
     fn discover_master_error(&self) -> Option<Error> {

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -169,9 +169,10 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) fn leak(mut self) -> Box<Path> {
+    /// Return ctl, master_log
+    pub(crate) fn leak(mut self) -> (Box<Path>, Option<Box<Path>>) {
         self.tempdir.take().unwrap().into_path();
-        self.ctl.clone()
+        (self.ctl.clone(), self.master_log.clone())
     }
 
     fn discover_master_error(&self) -> Option<Error> {

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -31,6 +31,18 @@ impl Session {
         }
     }
 
+    pub(crate) fn resume(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {
+        Self {
+            tempdir: None,
+            ctl,
+            // ssh don't care about the addr as long as we have the ctl.
+            //
+            // I tested this behavior on OpenSSH_8.9p1 Ubuntu-3, OpenSSL 3.0.2 15 Mar 2022
+            addr: "none".into(),
+            master_log,
+        }
+    }
+
     fn new_std_cmd(&self, args: &[impl AsRef<OsStr>]) -> std::process::Command {
         let mut cmd = std::process::Command::new("ssh");
         cmd.stdin(Stdio::null())

--- a/src/session.rs
+++ b/src/session.rs
@@ -317,8 +317,9 @@ impl Session {
     }
 
     /// Terminate the remote connection.
-    /// It would terminate the ssh multiplex server
-    /// regardless of how it is created.
+    ///
+    /// This destructor terminates the ssh multiplex server
+    /// regardless of how it was created.
     pub async fn close(self) -> Result<(), Error> {
         delegate!(self.0, imp, { imp.close().await })
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -67,6 +67,8 @@ impl From<native_mux_impl::Session> for Session {
 impl Session {
     /// Resume the connection using path to control socket and
     /// path to ssh multiplex output log.
+    ///
+    /// [`Session`] created this way will not be terminated on drop.
     #[cfg(feature = "process-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub fn resume(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {
@@ -75,6 +77,8 @@ impl Session {
 
     /// Resume the connection using path to control socket and
     /// path to ssh multiplex output log.
+    ///
+    /// [`Session`] created this way will not be terminated on drop.
     #[cfg(feature = "native-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-mux")))]
     pub fn resume_mux(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {

--- a/src/session.rs
+++ b/src/session.rs
@@ -328,10 +328,4 @@ impl Session {
     pub fn detach(self) -> (Box<Path>, Option<Box<Path>>) {
         delegate!(self.0, imp, { imp.detach() })
     }
-
-    /// Force terminate the remote connection, even if it is created
-    /// by [`Session::resume`] or [`Session::resume_mux`].
-    pub async fn force_terminate(self) -> Result<(), Error> {
-        delegate!(self.0, imp, { imp.force_terminate().await })
-    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -68,7 +68,8 @@ impl Session {
     /// Resume the connection using path to control socket and
     /// path to ssh multiplex output log.
     ///
-    /// [`Session`] created this way will not be terminated on drop.
+    /// [`Session`] created this way will not be terminated on drop,
+    /// but can be forced terminated by [`Session::force_terminate`].
     #[cfg(feature = "process-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub fn resume(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {
@@ -78,7 +79,8 @@ impl Session {
     /// Resume the connection using path to control socket and
     /// path to ssh multiplex output log.
     ///
-    /// [`Session`] created this way will not be terminated on drop.
+    /// [`Session`] created this way will not be terminated on drop,
+    /// but can be forced terminated by [`Session::force_terminate`].
     #[cfg(feature = "native-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-mux")))]
     pub fn resume_mux(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {

--- a/src/session.rs
+++ b/src/session.rs
@@ -321,10 +321,12 @@ impl Session {
         delegate!(self.0, imp, { imp.close().await })
     }
 
-    /// Leak the underlying ssh multiplex master.
+    /// Detach the lifetime of underlying ssh multiplex master
+    /// from this `Session`.
+    ///
     /// Return (path to control socket, path to ssh multiplex output log)
-    pub fn leak(self) -> (Box<Path>, Option<Box<Path>>) {
-        delegate!(self.0, imp, { imp.leak() })
+    pub fn detach(self) -> (Box<Path>, Option<Box<Path>>) {
+        delegate!(self.0, imp, { imp.detach() })
     }
 
     /// Force terminate the remote connection, even if it is created

--- a/src/session.rs
+++ b/src/session.rs
@@ -309,4 +309,10 @@ impl Session {
     pub async fn close(self) -> Result<(), Error> {
         delegate!(self.0, imp, { imp.close().await })
     }
+
+    /// Leak the underlying ssh multiplex master.
+    /// Return (path to control socket, path to ssh multiplex output log)
+    pub fn leak(self) -> (Box<Path>, Option<Box<Path>>) {
+        delegate!(self.0, imp, { imp.leak() })
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -65,14 +65,16 @@ impl From<native_mux_impl::Session> for Session {
 // TODO: UserKnownHostsFile for custom known host fingerprint.
 
 impl Session {
-    /// Resume the connection
+    /// Resume the connection using path to control socket and
+    /// path to ssh multiplex output log.
     #[cfg(feature = "process-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub fn resume(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {
         process_impl::Session::resume(ctl, master_log).into()
     }
 
-    /// Resume the connection
+    /// Resume the connection using path to control socket and
+    /// path to ssh multiplex output log.
     #[cfg(feature = "native-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-mux")))]
     pub fn resume_mux(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {

--- a/src/session.rs
+++ b/src/session.rs
@@ -65,6 +65,20 @@ impl From<native_mux_impl::Session> for Session {
 // TODO: UserKnownHostsFile for custom known host fingerprint.
 
 impl Session {
+    /// Resume the connection
+    #[cfg(feature = "process-mux")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
+    pub fn resume(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {
+        process_impl::Session::resume(ctl, master_log).into()
+    }
+
+    /// Resume the connection
+    #[cfg(feature = "native-mux")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-mux")))]
+    pub fn resume_mux(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {
+        native_mux_impl::Session::resume(ctl, master_log).into()
+    }
+
     /// Connect to the host at the given `host` over SSH using process impl, which will
     /// spawn a new ssh process for each `Child` created.
     ///

--- a/src/session.rs
+++ b/src/session.rs
@@ -68,19 +68,22 @@ impl Session {
     /// Resume the connection using path to control socket and
     /// path to ssh multiplex output log.
     ///
+    /// If you do not use `-E` option (or redirection) to write
+    /// the log of the ssh multiplex master to the disk, you can
+    /// simply pass `None` to `master_log`.
+    ///
     /// [`Session`] created this way will not be terminated on drop,
     /// but can be forced terminated by [`Session::force_terminate`].
+    ///
+    /// This connects to the ssh multiplex master using process mux impl.
     #[cfg(feature = "process-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub fn resume(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {
         process_impl::Session::resume(ctl, master_log).into()
     }
 
-    /// Resume the connection using path to control socket and
-    /// path to ssh multiplex output log.
-    ///
-    /// [`Session`] created this way will not be terminated on drop,
-    /// but can be forced terminated by [`Session::force_terminate`].
+    /// Same as [`Session::resume`] except that it connects to
+    /// the ssh multiplex master using process mux impl.
     #[cfg(feature = "native-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-mux")))]
     pub fn resume_mux(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {

--- a/src/session.rs
+++ b/src/session.rs
@@ -321,4 +321,10 @@ impl Session {
     pub fn leak(self) -> (Box<Path>, Option<Box<Path>>) {
         delegate!(self.0, imp, { imp.leak() })
     }
+
+    /// Force terminate the remote connection, even if it is created
+    /// by [`Session::resume`] or [`Session::resume_mux`].
+    pub async fn force_terminate(self) -> Result<(), Error> {
+        delegate!(self.0, imp, { imp.force_terminate().await })
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -83,7 +83,7 @@ impl Session {
     }
 
     /// Same as [`Session::resume`] except that it connects to
-    /// the ssh multiplex master using process mux impl.
+    /// the ssh multiplex master using native mux impl.
     #[cfg(feature = "native-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-mux")))]
     pub fn resume_mux(ctl: Box<Path>, master_log: Option<Box<Path>>) -> Self {

--- a/src/session.rs
+++ b/src/session.rs
@@ -73,7 +73,7 @@ impl Session {
     /// simply pass `None` to `master_log`.
     ///
     /// [`Session`] created this way will not be terminated on drop,
-    /// but can be forced terminated by [`Session::force_terminate`].
+    /// but can be forced terminated by [`Session::close`].
     ///
     /// This connects to the ssh multiplex master using process mux impl.
     #[cfg(feature = "process-mux")]
@@ -317,6 +317,8 @@ impl Session {
     }
 
     /// Terminate the remote connection.
+    /// It would terminate the ssh multiplex server
+    /// regardless of how it is created.
     pub async fn close(self) -> Result<(), Error> {
         delegate!(self.0, imp, { imp.close().await })
     }

--- a/start_sshd.sh
+++ b/start_sshd.sh
@@ -28,9 +28,10 @@ chmod 600 .test-key
 mkdir -p "$RUNTIME_DIR/openssh-rs/"
 
 echo Waiting for sshd to be up
-while ! ssh -i .test-key -v -p 2222 -l test-user $HOSTNAME -o StrictHostKeyChecking=no -o UserKnownHostsFile="$RUNTIME_DIR/openssh-rs/known_hosts" whoami; do
-    sleep 3
-done
+timeout 30 ./wait_for_sshd_start_up.sh
+
+# Add the ip to  known_hosts file
+ssh -i .test-key -v -p 2222 -l test-user $HOSTNAME -o StrictHostKeyChecking=no -o UserKnownHostsFile="$RUNTIME_DIR/openssh-rs/known_hosts" whoami
 
 # Create sshd_started in runtime directory so that it is auto removed on restart.
 touch "$RUNTIME_DIR/openssh-rs/sshd_started"

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -853,6 +853,22 @@ async fn test_leak_and_resume_process_mux() {
 
         session3.close().await.unwrap();
     }
+
+    // test force_terminate
+    for session1 in connects().await {
+        session1.check().await.unwrap();
+
+        let (ctl1, master_log1) = session1.leak();
+
+        let ctl = ctl1.clone();
+
+        let session2 = Session::resume(ctl1, master_log1);
+        session2.check().await.unwrap();
+
+        session2.force_terminate().await.unwrap();
+
+        assert!(!ctl.exists());
+    }
 }
 
 #[tokio::test]
@@ -878,6 +894,22 @@ async fn test_leak_and_resume_native_mux() {
         session3.check().await.unwrap();
 
         session3.close().await.unwrap();
+    }
+
+    // test force_terminate
+    for session1 in connects().await {
+        session1.check().await.unwrap();
+
+        let (ctl1, master_log1) = session1.leak();
+
+        let ctl = ctl1.clone();
+
+        let session2 = Session::resume_mux(ctl1, master_log1);
+        session2.check().await.unwrap();
+
+        session2.force_terminate().await.unwrap();
+
+        assert!(!ctl.exists());
     }
 }
 

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -854,7 +854,7 @@ async fn test_detach_and_resume_process_mux() {
         session3.close().await.unwrap();
     }
 
-    // test force_terminate
+    // test close
     for session1 in connects().await {
         session1.check().await.unwrap();
 
@@ -899,7 +899,7 @@ async fn test_detach_and_resume_native_mux() {
         session3.close().await.unwrap();
     }
 
-    // test force_terminate
+    // test close
     for session1 in connects().await {
         session1.check().await.unwrap();
 

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -865,7 +865,7 @@ async fn test_detach_and_resume_process_mux() {
         let session2 = Session::resume(ctl1, master_log1);
         session2.check().await.unwrap();
 
-        session2.force_terminate().await.unwrap();
+        session2.close().await.unwrap();
 
         // Wait for ssh multiplex master to clean up and exit.
         sleep(Duration::from_secs(3)).await;
@@ -910,7 +910,7 @@ async fn test_detach_and_resume_native_mux() {
         let session2 = Session::resume_mux(ctl1, master_log1);
         session2.check().await.unwrap();
 
-        session2.force_terminate().await.unwrap();
+        session2.close().await.unwrap();
 
         // Wait for ssh multiplex master to clean up and exit.
         sleep(Duration::from_secs(3)).await;

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -867,6 +867,9 @@ async fn test_detach_and_resume_process_mux() {
 
         session2.force_terminate().await.unwrap();
 
+        // Wait for ssh multiplex master to clean up and exit.
+        sleep(Duration::from_secs(3)).await;
+
         assert!(!ctl.exists());
     }
 }
@@ -908,6 +911,9 @@ async fn test_detach_and_resume_native_mux() {
         session2.check().await.unwrap();
 
         session2.force_terminate().await.unwrap();
+
+        // Wait for ssh multiplex master to clean up and exit.
+        sleep(Duration::from_secs(3)).await;
 
         assert!(!ctl.exists());
     }

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -831,6 +831,58 @@ async fn local_socket_forward() {
 
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]
+#[cfg(feature = "process-mux")]
+async fn test_leak_and_resume_process_mux() {
+    for session1 in connects().await {
+        session1.check().await.unwrap();
+
+        // First leak
+        let (ctl1, master_log1) = session1.leak();
+
+        // First resume
+        let session2 = Session::resume(ctl1, master_log1);
+        session2.check().await.unwrap();
+
+        // Second leak to ensure leak handles tempdir
+        // set to None correctly.
+        let (ctl2, master_log2) = session2.leak();
+
+        // Second resume to ensure close handles tempdir set to None correctly
+        let session3 = Session::resume(ctl2, master_log2);
+        session3.check().await.unwrap();
+
+        session3.close().await.unwrap();
+    }
+}
+
+#[tokio::test]
+#[cfg_attr(not(ci), ignore)]
+#[cfg(feature = "native-mux")]
+async fn test_leak_and_resume_native_mux() {
+    for session1 in connects().await {
+        session1.check().await.unwrap();
+
+        // First leak
+        let (ctl1, master_log1) = session1.leak();
+
+        // First resume_mux
+        let session2 = Session::resume_mux(ctl1, master_log1);
+        session2.check().await.unwrap();
+
+        // Second leak to ensure leak handles tempdir
+        // set to None correctly.
+        let (ctl2, master_log2) = session2.leak();
+
+        // Second resume_mux to ensure close handles tempdir set to None correctly
+        let session3 = Session::resume_mux(ctl2, master_log2);
+        session3.check().await.unwrap();
+
+        session3.close().await.unwrap();
+    }
+}
+
+#[tokio::test]
+#[cfg_attr(not(ci), ignore)]
 async fn test_sftp_subsystem() {
     use openssh_sftp_client::highlevel::Sftp;
 

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -832,20 +832,20 @@ async fn local_socket_forward() {
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]
 #[cfg(feature = "process-mux")]
-async fn test_leak_and_resume_process_mux() {
+async fn test_detach_and_resume_process_mux() {
     for session1 in connects().await {
         session1.check().await.unwrap();
 
-        // First leak
-        let (ctl1, master_log1) = session1.leak();
+        // First detach
+        let (ctl1, master_log1) = session1.detach();
 
         // First resume
         let session2 = Session::resume(ctl1, master_log1);
         session2.check().await.unwrap();
 
-        // Second leak to ensure leak handles tempdir
+        // Second detach to ensure detach handles tempdir
         // set to None correctly.
-        let (ctl2, master_log2) = session2.leak();
+        let (ctl2, master_log2) = session2.detach();
 
         // Second resume to ensure close handles tempdir set to None correctly
         let session3 = Session::resume(ctl2, master_log2);
@@ -858,7 +858,7 @@ async fn test_leak_and_resume_process_mux() {
     for session1 in connects().await {
         session1.check().await.unwrap();
 
-        let (ctl1, master_log1) = session1.leak();
+        let (ctl1, master_log1) = session1.detach();
 
         let ctl = ctl1.clone();
 
@@ -874,20 +874,20 @@ async fn test_leak_and_resume_process_mux() {
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]
 #[cfg(feature = "native-mux")]
-async fn test_leak_and_resume_native_mux() {
+async fn test_detach_and_resume_native_mux() {
     for session1 in connects().await {
         session1.check().await.unwrap();
 
-        // First leak
-        let (ctl1, master_log1) = session1.leak();
+        // First detach
+        let (ctl1, master_log1) = session1.detach();
 
         // First resume_mux
         let session2 = Session::resume_mux(ctl1, master_log1);
         session2.check().await.unwrap();
 
-        // Second leak to ensure leak handles tempdir
+        // Second detach to ensure detach handles tempdir
         // set to None correctly.
-        let (ctl2, master_log2) = session2.leak();
+        let (ctl2, master_log2) = session2.detach();
 
         // Second resume_mux to ensure close handles tempdir set to None correctly
         let session3 = Session::resume_mux(ctl2, master_log2);
@@ -900,7 +900,7 @@ async fn test_leak_and_resume_native_mux() {
     for session1 in connects().await {
         session1.check().await.unwrap();
 
-        let (ctl1, master_log1) = session1.leak();
+        let (ctl1, master_log1) = session1.detach();
 
         let ctl = ctl1.clone();
 

--- a/wait_for_sshd_start_up.sh
+++ b/wait_for_sshd_start_up.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+until ssh-keyscan -p 2222 localhost; do
+    sleep 1
+done


### PR DESCRIPTION
Fixed #72 

This PR adds:
 - `Session::leak`
 - `Session::resume`
 - `Session::resume_mux`
 - `Session::force_terminate`

and integration tests for them.

This PR also added a minor change to `.github/workflows/style.yml` to make sure it failed on warnings like missing items and updated `run_ci_tests.sh` to remove temp dirs.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

Edit:

It also [Fix random error in step "Test ssh connectivity"](https://github.com/openssh-rust/openssh/pull/80/commits/39298e7ce884be8175af6a74d58cef9bc81eae3a).