### PR TITLE
Add documentation link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "SSH through OpenSSH"
 repository = "https://github.com/openssh-rust/openssh.git"
+documentation = "https://docs.rs/openssh"
 
 keywords = ["ssh","remote","openssh","orchestration"]
 categories = ["network-programming", "api-bindings"]


### PR DESCRIPTION
Whenever you search for openssh in crates.io, this will add a "Documentation" link under the crate's name. This removes the annoying extra click of going into the crate's README if you know you only want to get to the documentation.