### PR TITLE
Optimize and make `request_port_forward` easier to use

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -49,6 +49,7 @@ jobs:
           # we cannot use 127.0.0.1 (the default here)
           # since we are running from a different container
           TEST_HOST: ssh://test-user@localhost:2222
+          XDG_RUNTIME_DIR: /tmp
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -55,6 +55,7 @@ jobs:
         env:
           # makes all the ignored tests not ignored
           RUSTFLAGS: --cfg=ci
+          XDG_RUNTIME_DIR: /tmp
     services:
       openssh:
         image: linuxserver/openssh-server:amd64-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
         env:
           # makes all the ignored tests not ignored
           RUSTFLAGS: --cfg=ci
+          XDG_RUNTIME_DIR: /tmp
       - run: docker logs $(docker ps | grep openssh-server | awk '{print $1}')
         name: ssh container log
         if: ${{ failure() }}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -206,11 +206,11 @@ impl SessionBuilder {
     pub(super) async fn connect_impl(
         &self,
         destination: &str,
-        f: fn(TempDir) -> Session,
+        f: fn(TempDir, &str) -> Session,
     ) -> Result<Session, Error> {
         let (builder, destination) = self.resolve(destination);
         let tempdir = builder.launch_master(destination).await?;
-        Ok(f(tempdir))
+        Ok(f(tempdir, destination))
     }
 
     fn resolve<'a, 'b>(&'a self, mut destination: &'b str) -> (Cow<'a, Self>, &'b str) {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -185,8 +185,8 @@ impl SessionBuilder {
     #[cfg(feature = "process-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub async fn connect<S: AsRef<str>>(&self, destination: S) -> Result<Session, Error> {
-        self.connect_impl(destination.as_ref(), |tempdir, destination| {
-            process_impl::Session::new(tempdir, destination).into()
+        self.connect_impl(destination.as_ref(), |tempdir| {
+            process_impl::Session::new(tempdir).into()
         })
         .await
     }
@@ -207,7 +207,7 @@ impl SessionBuilder {
     #[cfg(feature = "native-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-mux")))]
     pub async fn connect_mux<S: AsRef<str>>(&self, destination: S) -> Result<Session, Error> {
-        self.connect_impl(destination.as_ref(), |tempdir, _destination| {
+        self.connect_impl(destination.as_ref(), |tempdir| {
             native_mux_impl::Session::new(tempdir).into()
         })
         .await
@@ -216,11 +216,11 @@ impl SessionBuilder {
     async fn connect_impl(
         &self,
         destination: &str,
-        f: fn(TempDir, &str) -> Session,
+        f: fn(TempDir) -> Session,
     ) -> Result<Session, Error> {
         let (builder, destination) = self.resolve(destination);
         let tempdir = builder.launch_master(destination).await?;
-        Ok(f(tempdir, destination))
+        Ok(f(tempdir))
     }
 
     fn resolve<'a, 'b>(&'a self, mut destination: &'b str) -> (Cow<'a, Self>, &'b str) {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,11 +1,5 @@
 use super::{Error, Session};
 
-#[cfg(feature = "process-mux")]
-use super::process_impl;
-
-#[cfg(feature = "native-mux")]
-use super::native_mux_impl;
-
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::fs;
@@ -185,10 +179,8 @@ impl SessionBuilder {
     #[cfg(feature = "process-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub async fn connect<S: AsRef<str>>(&self, destination: S) -> Result<Session, Error> {
-        self.connect_impl(destination.as_ref(), |tempdir| {
-            process_impl::Session::new(tempdir).into()
-        })
-        .await
+        self.connect_impl(destination.as_ref(), Session::new_process_mux)
+            .await
     }
 
     /// Connect to the host at the given `host` over SSH using native mux, which will
@@ -207,10 +199,8 @@ impl SessionBuilder {
     #[cfg(feature = "native-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-mux")))]
     pub async fn connect_mux<S: AsRef<str>>(&self, destination: S) -> Result<Session, Error> {
-        self.connect_impl(destination.as_ref(), |tempdir| {
-            native_mux_impl::Session::new(tempdir).into()
-        })
-        .await
+        self.connect_impl(destination.as_ref(), Session::new_native_mux)
+            .await
     }
 
     async fn connect_impl(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -206,11 +206,11 @@ impl SessionBuilder {
     pub(super) async fn connect_impl(
         &self,
         destination: &str,
-        f: fn(TempDir, &str) -> Session,
+        f: fn(TempDir) -> Session,
     ) -> Result<Session, Error> {
         let (builder, destination) = self.resolve(destination);
         let tempdir = builder.launch_master(destination).await?;
-        Ok(f(tempdir, destination))
+        Ok(f(tempdir))
     }
 
     fn resolve<'a, 'b>(&'a self, mut destination: &'b str) -> (Cow<'a, Self>, &'b str) {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -203,7 +203,7 @@ impl SessionBuilder {
             .await
     }
 
-    pub(super) async fn connect_impl(
+    async fn connect_impl(
         &self,
         destination: &str,
         f: fn(TempDir) -> Session,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -203,7 +203,7 @@ impl SessionBuilder {
             .await
     }
 
-    async fn connect_impl(
+    pub(super) async fn connect_impl(
         &self,
         destination: &str,
         f: fn(TempDir) -> Session,

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -17,23 +17,6 @@ use crate::*;
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`
 ///    to make it much easier to use.
 ///  - [`Socket::new`] now returns `Socket<'static>`
-///
-/// ## Optimized
-///  - [`Command::arg`]: Avoid duplicate monomorphization
-///  - [`Command::raw_arg`]: Avoid duplicate monomorphization
-///  - [`Command::stdin`]: Avoid duplicate monomorphization
-///  - [`Command::stdout`]: Avoid duplicate monomorphization
-///  - [`Command::stderr`]: Avoid duplicate monomorphization
-///  - [`SessionBuilder::connect`]: Avoid duplicate monomorphization
-///  - [`SessionBuilder::connect_mux`]: Avoid duplicate monomorphization
-///  - [`Session::connect`]: Avoid duplicate monomorphization
-///  - [`Session::connect_mux`]: Avoid duplicate monomorphization
-///  - [`Session::command`]: Avoid duplicate monomorphization
-///  - [`Session::raw_command`]: Avoid duplicate monomorphization
-///  - [`Session::subsystem`]: Avoid duplicate monomorphization
-///  - [`Session::shell`]: Avoid duplicate monomorphization
-///  - [`Socket::new`]: Avoid duplicate monomorphization
-///  - Make [`Session`] more compact: Rm "addr" field in process-mux mode
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -5,6 +5,7 @@ use crate::*;
 ///
 /// ## Added
 ///  - `From<SocketAddr> for Socket<'static>`
+///  - `From<Cow<'a, Path>> for Socket<'a>`
 ///
 /// ## Changed
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -17,6 +17,7 @@ use crate::*;
 ///  - [`Session::raw_command`]: Avoid duplicate monomorphization
 ///  - [`Session::subsystem`]: Avoid duplicate monomorphization
 ///  - [`Session::shell`]: Avoid duplicate monomorphization
+///  - [`Socket::new`]: Avoid duplicate monomorphization
 ///  - Make [`Session`] more compact: Rm "addr" field in process-mux mode
 #[doc(hidden)]
 pub mod unreleased {}

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -8,6 +8,7 @@ use crate::*;
 ///  - `From<Cow<'a, Path>> for Socket<'a>`
 ///  - `From<&'a Path> for Socket<'a>`
 ///  - `From<PathBuf> for Socket<'a>`
+///  - `From<Box<Path>> for Socket<'a>`
 ///
 /// ## Changed
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -7,6 +7,7 @@ use crate::*;
 ///  - [`Command::arg`]: Avoid duplicate monomorphization
 ///  - [`Command::raw_arg`]: Avoid duplicate monomorphization
 ///  - [`Command::stdin`]: Avoid duplicate monomorphization
+///  - [`Command::stdout`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect_mux`]: Avoid duplicate monomorphization
 ///  - [`Session::connect`]: Avoid duplicate monomorphization

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -8,6 +8,8 @@ use crate::*;
 ///  - [`Command::raw_arg`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect_mux`]: Avoid duplicate monomorphization
+///  - [`Session::connect`]: Avoid duplicate monomorphization
+///  - [`Session::connect_mux`]: Avoid duplicate monomorphization
 ///  - Make [`Session`] more compact: Rm "addr" field in process-mux mode
 #[doc(hidden)]
 pub mod unreleased {}

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -11,6 +11,7 @@ use crate::*;
 ///  - `From<Box<Path>> for Socket<'static>`
 ///  - `From<(IpAddr, u16)> for Socket<'static>`
 ///  - `From<(Ipv4Addr, u16)> for Socket<'static>`
+///  - `From<(Ipv6Addr, u16)> for Socket<'static>`
 ///
 /// ## Changed
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -6,6 +6,7 @@ use crate::*;
 /// ## Added
 ///  - `From<SocketAddr> for Socket<'static>`
 ///  - `From<Cow<'a, Path>> for Socket<'a>`
+///  - `From<&'a Path> for Socket<'a>`
 ///
 /// ## Changed
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -10,6 +10,7 @@ use crate::*;
 ///  - `From<PathBuf> for Socket<'static>`
 ///  - `From<Box<Path>> for Socket<'static>`
 ///  - `From<(IpAddr, u16)> for Socket<'static>`
+///  - `From<(Ipv4Addr, u16)> for Socket<'static>`
 ///
 /// ## Changed
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -3,6 +3,10 @@ use crate::*;
 
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
 ///
+/// ## Changed
+///  - [`Session::request_port_forward`] now takes `impl Into<...>`
+///    to make it much easier to use.
+///
 /// ## Optimized
 ///  - [`Command::arg`]: Avoid duplicate monomorphization
 ///  - [`Command::raw_arg`]: Avoid duplicate monomorphization

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -3,6 +3,9 @@ use crate::*;
 
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
 ///
+/// ## Added
+///  - `From<SocketAddr> for Socket<'static>`
+///
 /// ## Changed
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`
 ///    to make it much easier to use.

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -13,6 +13,7 @@ use crate::*;
 ///  - [`Session::command`]: Avoid duplicate monomorphization
 ///  - [`Session::raw_command`]: Avoid duplicate monomorphization
 ///  - [`Session::subsystem`]: Avoid duplicate monomorphization
+///  - [`Session::shell`]: Avoid duplicate monomorphization
 ///  - Make [`Session`] more compact: Rm "addr" field in process-mux mode
 #[doc(hidden)]
 pub mod unreleased {}

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -11,6 +11,7 @@ use crate::*;
 ///  - [`Session::connect`]: Avoid duplicate monomorphization
 ///  - [`Session::connect_mux`]: Avoid duplicate monomorphization
 ///  - [`Session::command`]: Avoid duplicate monomorphization
+///  - [`Session::raw_command`]: Avoid duplicate monomorphization
 ///  - Make [`Session`] more compact: Rm "addr" field in process-mux mode
 #[doc(hidden)]
 pub mod unreleased {}

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -6,6 +6,7 @@ use crate::*;
 /// ## Changed
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`
 ///    to make it much easier to use.
+///  - [`Socket::new`] now returns `Socket<'static>`
 ///
 /// ## Optimized
 ///  - [`Command::arg`]: Avoid duplicate monomorphization

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -7,8 +7,8 @@ use crate::*;
 ///  - `From<SocketAddr> for Socket<'static>`
 ///  - `From<Cow<'a, Path>> for Socket<'a>`
 ///  - `From<&'a Path> for Socket<'a>`
-///  - `From<PathBuf> for Socket<'a>`
-///  - `From<Box<Path>> for Socket<'a>`
+///  - `From<PathBuf> for Socket<'static>`
+///  - `From<Box<Path>> for Socket<'static>`
 ///  - `From<(IpAddr, u16)> for Socket<'static>`
 ///
 /// ## Changed

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -7,6 +7,7 @@ use crate::*;
 ///  - `From<SocketAddr> for Socket<'static>`
 ///  - `From<Cow<'a, Path>> for Socket<'a>`
 ///  - `From<&'a Path> for Socket<'a>`
+///  - `From<PathBuf> for Socket<'a>`
 ///
 /// ## Changed
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -10,6 +10,7 @@ use crate::*;
 ///  - [`SessionBuilder::connect_mux`]: Avoid duplicate monomorphization
 ///  - [`Session::connect`]: Avoid duplicate monomorphization
 ///  - [`Session::connect_mux`]: Avoid duplicate monomorphization
+///  - [`Session::command`]: Avoid duplicate monomorphization
 ///  - Make [`Session`] more compact: Rm "addr" field in process-mux mode
 #[doc(hidden)]
 pub mod unreleased {}

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -8,6 +8,7 @@ use crate::*;
 ///  - [`Command::raw_arg`]: Avoid duplicate monomorphization
 ///  - [`Command::stdin`]: Avoid duplicate monomorphization
 ///  - [`Command::stdout`]: Avoid duplicate monomorphization
+///  - [`Command::stderr`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect_mux`]: Avoid duplicate monomorphization
 ///  - [`Session::connect`]: Avoid duplicate monomorphization

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -2,6 +2,10 @@
 use crate::*;
 
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
+///
+/// ## Optimized
+///  - [`Command::arg`]: Avoid duplicate monomorphization
+///  - [`Command::raw_arg`]: Avoid duplicate monomorphization
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -12,6 +12,7 @@ use crate::*;
 ///  - [`Session::connect_mux`]: Avoid duplicate monomorphization
 ///  - [`Session::command`]: Avoid duplicate monomorphization
 ///  - [`Session::raw_command`]: Avoid duplicate monomorphization
+///  - [`Session::subsystem`]: Avoid duplicate monomorphization
 ///  - Make [`Session`] more compact: Rm "addr" field in process-mux mode
 #[doc(hidden)]
 pub mod unreleased {}

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -8,6 +8,7 @@ use crate::*;
 ///  - [`Command::raw_arg`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect_mux`]: Avoid duplicate monomorphization
+///  - Make [`Session`] more compact: Rm "addr" field in process-mux mode
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -9,6 +9,7 @@ use crate::*;
 ///  - `From<&'a Path> for Socket<'a>`
 ///  - `From<PathBuf> for Socket<'a>`
 ///  - `From<Box<Path>> for Socket<'a>`
+///  - `From<(IpAddr, u16)> for Socket<'static>`
 ///
 /// ## Changed
 ///  - [`Session::request_port_forward`] now takes `impl Into<...>`

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -6,6 +6,8 @@ use crate::*;
 /// ## Optimized
 ///  - [`Command::arg`]: Avoid duplicate monomorphization
 ///  - [`Command::raw_arg`]: Avoid duplicate monomorphization
+///  - [`SessionBuilder::connect`]: Avoid duplicate monomorphization
+///  - [`SessionBuilder::connect_mux`]: Avoid duplicate monomorphization
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -6,6 +6,7 @@ use crate::*;
 /// ## Optimized
 ///  - [`Command::arg`]: Avoid duplicate monomorphization
 ///  - [`Command::raw_arg`]: Avoid duplicate monomorphization
+///  - [`Command::stdin`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect`]: Avoid duplicate monomorphization
 ///  - [`SessionBuilder::connect_mux`]: Avoid duplicate monomorphization
 ///  - [`Session::connect`]: Avoid duplicate monomorphization

--- a/src/command.rs
+++ b/src/command.rs
@@ -126,7 +126,14 @@ impl<'s> Command<'s> {
     ///
     /// To pass multiple arguments see [`args`](Command::args).
     pub fn arg<S: AsRef<str>>(&mut self, arg: S) -> &mut Self {
-        self.raw_arg(&*shell_escape::unix::escape(Cow::Borrowed(arg.as_ref())))
+        fn inner<'this, 'cmd>(
+            this: &'this mut Command<'cmd>,
+            arg: &str,
+        ) -> &'this mut Command<'cmd> {
+            this.raw_arg(&*shell_escape::unix::escape(Cow::Borrowed(arg)))
+        }
+
+        inner(self, arg.as_ref())
     }
 
     /// Adds an argument to pass to the remote program.

--- a/src/command.rs
+++ b/src/command.rs
@@ -126,10 +126,7 @@ impl<'s> Command<'s> {
     ///
     /// To pass multiple arguments see [`args`](Command::args).
     pub fn arg<S: AsRef<str>>(&mut self, arg: S) -> &mut Self {
-        fn inner<'this, 'cmd>(
-            this: &'this mut Command<'cmd>,
-            arg: &str,
-        ) -> &'this mut Command<'cmd> {
+        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, arg: &str) -> &'cmd mut Command<'s> {
             this.raw_arg(&*shell_escape::unix::escape(Cow::Borrowed(arg)))
         }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -126,11 +126,7 @@ impl<'s> Command<'s> {
     ///
     /// To pass multiple arguments see [`args`](Command::args).
     pub fn arg<S: AsRef<str>>(&mut self, arg: S) -> &mut Self {
-        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, arg: &str) -> &'cmd mut Command<'s> {
-            this.raw_arg(&*shell_escape::unix::escape(Cow::Borrowed(arg)))
-        }
-
-        inner(self, arg.as_ref())
+        self.raw_arg(&*shell_escape::unix::escape(Cow::Borrowed(arg.as_ref())))
     }
 
     /// Adds an argument to pass to the remote program.
@@ -142,14 +138,10 @@ impl<'s> Command<'s> {
     ///
     /// To pass multiple unescaped arguments see [`raw_args`](Command::raw_args).
     pub fn raw_arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
-        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, arg: &OsStr) -> &'cmd mut Command<'s> {
-            delegate!(&mut this.imp, imp, {
-                imp.raw_arg(arg);
-            });
-            this
-        }
-
-        inner(self, arg.as_ref())
+        delegate!(&mut self.imp, imp, {
+            imp.raw_arg(arg.as_ref());
+        });
+        self
     }
 
     /// Adds multiple arguments to pass to the remote program.
@@ -197,15 +189,11 @@ impl<'s> Command<'s> {
     /// [`inherit`]: struct.Stdio.html#method.inherit
     /// [`null`]: struct.Stdio.html#method.null
     pub fn stdin<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
-        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, cfg: Stdio) -> &'cmd mut Command<'s> {
-            delegate!(&mut this.imp, imp, {
-                imp.stdin(cfg);
-            });
-            this.stdin_set = true;
-            this
-        }
-
-        inner(self, cfg.into())
+        delegate!(&mut self.imp, imp, {
+            imp.stdin(cfg.into());
+        });
+        self.stdin_set = true;
+        self
     }
 
     /// Configuration for the remote process's standard output (stdout) handle.
@@ -216,15 +204,11 @@ impl<'s> Command<'s> {
     /// [`inherit`]: struct.Stdio.html#method.inherit
     /// [`piped`]: struct.Stdio.html#method.piped
     pub fn stdout<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
-        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, cfg: Stdio) -> &'cmd mut Command<'s> {
-            delegate!(&mut this.imp, imp, {
-                imp.stdout(cfg);
-            });
-            this.stdout_set = true;
-            this
-        }
-
-        inner(self, cfg.into())
+        delegate!(&mut self.imp, imp, {
+            imp.stdout(cfg.into());
+        });
+        self.stdout_set = true;
+        self
     }
 
     /// Configuration for the remote process's standard error (stderr) handle.
@@ -235,15 +219,11 @@ impl<'s> Command<'s> {
     /// [`inherit`]: struct.Stdio.html#method.inherit
     /// [`piped`]: struct.Stdio.html#method.piped
     pub fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
-        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, cfg: Stdio) -> &'cmd mut Command<'s> {
-            delegate!(&mut this.imp, imp, {
-                imp.stderr(cfg);
-            });
-            this.stderr_set = true;
-            this
-        }
-
-        inner(self, cfg.into())
+        delegate!(&mut self.imp, imp, {
+            imp.stderr(cfg.into());
+        });
+        self.stderr_set = true;
+        self
     }
 
     async fn spawn_impl(&mut self) -> Result<RemoteChild<'s>, Error> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -235,11 +235,15 @@ impl<'s> Command<'s> {
     /// [`inherit`]: struct.Stdio.html#method.inherit
     /// [`piped`]: struct.Stdio.html#method.piped
     pub fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
-        delegate!(&mut self.imp, imp, {
-            imp.stderr(cfg.into());
-        });
-        self.stderr_set = true;
-        self
+        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, cfg: Stdio) -> &'cmd mut Command<'s> {
+            delegate!(&mut this.imp, imp, {
+                imp.stderr(cfg);
+            });
+            this.stderr_set = true;
+            this
+        }
+
+        inner(self, cfg.into())
     }
 
     async fn spawn_impl(&mut self) -> Result<RemoteChild<'s>, Error> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -197,11 +197,15 @@ impl<'s> Command<'s> {
     /// [`inherit`]: struct.Stdio.html#method.inherit
     /// [`null`]: struct.Stdio.html#method.null
     pub fn stdin<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
-        delegate!(&mut self.imp, imp, {
-            imp.stdin(cfg.into());
-        });
-        self.stdin_set = true;
-        self
+        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, cfg: Stdio) -> &'cmd mut Command<'s> {
+            delegate!(&mut this.imp, imp, {
+                imp.stdin(cfg);
+            });
+            this.stdin_set = true;
+            this
+        }
+
+        inner(self, cfg.into())
     }
 
     /// Configuration for the remote process's standard output (stdout) handle.

--- a/src/command.rs
+++ b/src/command.rs
@@ -216,11 +216,15 @@ impl<'s> Command<'s> {
     /// [`inherit`]: struct.Stdio.html#method.inherit
     /// [`piped`]: struct.Stdio.html#method.piped
     pub fn stdout<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Self {
-        delegate!(&mut self.imp, imp, {
-            imp.stdout(cfg.into());
-        });
-        self.stdout_set = true;
-        self
+        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, cfg: Stdio) -> &'cmd mut Command<'s> {
+            delegate!(&mut this.imp, imp, {
+                imp.stdout(cfg);
+            });
+            this.stdout_set = true;
+            this
+        }
+
+        inner(self, cfg.into())
     }
 
     /// Configuration for the remote process's standard error (stderr) handle.

--- a/src/command.rs
+++ b/src/command.rs
@@ -23,7 +23,7 @@ impl From<super::process_impl::Command> for CommandImp {
 }
 
 #[cfg(feature = "native-mux")]
-impl<'s> From<super::native_mux_impl::Command> for CommandImp {
+impl From<super::native_mux_impl::Command> for CommandImp {
     fn from(imp: super::native_mux_impl::Command) -> Self {
         CommandImp::NativeMuxImpl(imp)
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -145,10 +145,14 @@ impl<'s> Command<'s> {
     ///
     /// To pass multiple unescaped arguments see [`raw_args`](Command::raw_args).
     pub fn raw_arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
-        delegate!(&mut self.imp, imp, {
-            imp.raw_arg(arg.as_ref());
-        });
-        self
+        fn inner<'cmd, 's>(this: &'cmd mut Command<'s>, arg: &OsStr) -> &'cmd mut Command<'s> {
+            delegate!(&mut this.imp, imp, {
+                imp.raw_arg(arg);
+            });
+            this
+        }
+
+        inner(self, arg.as_ref())
     }
 
     /// Adds multiple arguments to pass to the remote program.

--- a/src/command.rs
+++ b/src/command.rs
@@ -146,7 +146,7 @@ impl<'s> Command<'s> {
     /// To pass multiple unescaped arguments see [`raw_args`](Command::raw_args).
     pub fn raw_arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
         delegate!(&mut self.imp, imp, {
-            imp.raw_arg(arg);
+            imp.raw_arg(arg.as_ref());
         });
         self
     }

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -51,17 +51,13 @@ impl Session {
 
     pub(crate) async fn request_port_forward(
         &self,
-        forward_type: impl Into<ForwardType>,
-        listen_socket: impl Into<Socket<'_>>,
-        connect_socket: impl Into<Socket<'_>>,
+        forward_type: ForwardType,
+        listen_socket: Socket<'_>,
+        connect_socket: Socket<'_>,
     ) -> Result<(), Error> {
         Connection::connect(&self.ctl)
             .await?
-            .request_port_forward(
-                forward_type.into(),
-                &listen_socket.into(),
-                &connect_socket.into(),
-            )
+            .request_port_forward(forward_type, &listen_socket, &connect_socket)
             .await?;
 
         Ok(())

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -76,17 +76,13 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) async fn close(mut self) -> Result<(), Error> {
-        // This also set self.tempdir to None so that Drop::drop would do nothing.
-        if let Some(tempdir) = self.tempdir.take() {
-            self.close_impl().await?;
+    pub(crate) async fn close(mut self) -> Result<Option<TempDir>, Error> {
+        // Take self.tempdir so that drop would do nothing
+        let tempdir = self.tempdir.take();
 
-            tempdir.close().map_err(Error::Cleanup)?;
-        } else {
-            self.close_impl().await?;
-        }
+        self.close_impl().await?;
 
-        Ok(())
+        Ok(tempdir)
     }
 
     pub(crate) fn detach(mut self) -> (Box<Path>, Option<Box<Path>>) {

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -1,4 +1,4 @@
-use super::{Command, Error, ForwardType, Socket};
+use super::{Command, Error};
 
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
@@ -51,13 +51,17 @@ impl Session {
 
     pub(crate) async fn request_port_forward(
         &self,
-        forward_type: ForwardType,
-        listen_socket: Socket<'_>,
-        connect_socket: Socket<'_>,
+        forward_type: crate::ForwardType,
+        listen_socket: crate::Socket<'_>,
+        connect_socket: crate::Socket<'_>,
     ) -> Result<(), Error> {
         Connection::connect(&self.ctl)
             .await?
-            .request_port_forward(forward_type, &listen_socket, &connect_socket)
+            .request_port_forward(
+                forward_type.into(),
+                &listen_socket.into(),
+                &connect_socket.into(),
+            )
             .await?;
 
         Ok(())

--- a/src/native_mux_impl/stdio.rs
+++ b/src/native_mux_impl/stdio.rs
@@ -62,10 +62,7 @@ impl Stdio {
         }
     }
 
-    fn to_output(
-        &self,
-        get_inherit_rawfd: impl FnOnce() -> RawFd,
-    ) -> Result<(Fd, Option<PipeRead>), Error> {
+    fn to_output(&self, get_inherit_rawfd: fn() -> RawFd) -> Result<(Fd, Option<PipeRead>), Error> {
         match &self.0 {
             StdioImpl::Inherit => Ok((Fd::Borrowed(get_inherit_rawfd()), None)),
             StdioImpl::Null => Ok((Fd::Null, None)),

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -100,15 +100,10 @@ impl From<Box<Path>> for Socket<'static> {
 impl Socket<'_> {
     /// Create a new TcpSocket
     pub fn new<T: ToSocketAddrs>(addr: &T) -> Result<Socket<'static>, io::Error> {
-        fn inner(it: &mut dyn Iterator<Item = SocketAddr>) -> Result<Socket<'static>, io::Error> {
-            it.next()
-                .ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::Other, "no more socket addresses to try")
-                })
-                .map(Socket::TcpSocket)
-        }
-
-        inner(&mut addr.to_socket_addrs()?)
+        addr.to_socket_addrs()?
+            .next()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "no more socket addresses to try"))
+            .map(Socket::TcpSocket)
     }
 
     #[cfg(feature = "process-mux")]

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -47,6 +47,12 @@ pub enum Socket<'a> {
     TcpSocket(SocketAddr),
 }
 
+impl From<SocketAddr> for Socket<'static> {
+    fn from(addr: SocketAddr) -> Self {
+        Socket::TcpSocket(addr)
+    }
+}
+
 impl Socket<'_> {
     /// Create a new TcpSocket
     pub fn new<T: ToSocketAddrs>(addr: &T) -> Result<Socket<'static>, io::Error> {

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -64,6 +64,7 @@ macro_rules! impl_from_addr {
 }
 
 impl_from_addr!(net::IpAddr);
+impl_from_addr!(net::Ipv4Addr);
 
 impl<'a> From<Cow<'a, Path>> for Socket<'a> {
     fn from(path: Cow<'a, Path>) -> Self {

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -7,7 +7,7 @@ use std::ffi::OsStr;
 use std::borrow::Cow;
 use std::fmt;
 use std::io;
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{self, SocketAddr, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 
 /// Type of forwarding
@@ -52,6 +52,19 @@ impl From<SocketAddr> for Socket<'static> {
         Socket::TcpSocket(addr)
     }
 }
+
+macro_rules! impl_from_addr {
+    ($ip:ty) => {
+        impl From<($ip, u16)> for Socket<'static> {
+            fn from(addr: ($ip, u16)) -> Self {
+                Socket::new(&addr).unwrap()
+            }
+        }
+    };
+}
+
+impl_from_addr!(net::IpAddr);
+
 impl<'a> From<Cow<'a, Path>> for Socket<'a> {
     fn from(path: Cow<'a, Path>) -> Self {
         Socket::UnixSocket { path }

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -58,6 +58,14 @@ impl<'a> From<Cow<'a, Path>> for Socket<'a> {
     }
 }
 
+impl<'a> From<&'a Path> for Socket<'a> {
+    fn from(path: &'a Path) -> Self {
+        Socket::UnixSocket {
+            path: Cow::Borrowed(path),
+        }
+    }
+}
+
 impl Socket<'_> {
     /// Create a new TcpSocket
     pub fn new<T: ToSocketAddrs>(addr: &T) -> Result<Socket<'static>, io::Error> {

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -46,9 +46,10 @@ pub enum Socket<'a> {
     /// Tcp socket.
     TcpSocket(SocketAddr),
 }
+
 impl Socket<'_> {
     /// Create a new TcpSocket
-    pub fn new<T: ToSocketAddrs>(addr: &T) -> Result<Self, io::Error> {
+    pub fn new<T: ToSocketAddrs>(addr: &T) -> Result<Socket<'static>, io::Error> {
         fn inner(it: &mut dyn Iterator<Item = SocketAddr>) -> Result<Socket<'static>, io::Error> {
             it.next()
                 .ok_or_else(|| {

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Type of forwarding
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -62,6 +62,14 @@ impl<'a> From<&'a Path> for Socket<'a> {
     fn from(path: &'a Path) -> Self {
         Socket::UnixSocket {
             path: Cow::Borrowed(path),
+        }
+    }
+}
+
+impl From<PathBuf> for Socket<'static> {
+    fn from(path: PathBuf) -> Self {
+        Socket::UnixSocket {
+            path: Cow::Owned(path),
         }
     }
 }

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -50,11 +50,11 @@ impl Socket<'_> {
     /// Create a new TcpSocket
     pub fn new<T: ToSocketAddrs>(addr: &T) -> Result<Self, io::Error> {
         fn inner(it: &mut dyn Iterator<Item = SocketAddr>) -> Result<Socket<'static>, io::Error> {
-            let addr = it.next().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::Other, "no more socket addresses to try")
-            })?;
-
-            Ok(Socket::TcpSocket(addr))
+            it.next()
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::Other, "no more socket addresses to try")
+                })
+                .map(Socket::TcpSocket)
         }
 
         inner(&mut addr.to_socket_addrs()?)

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -52,6 +52,11 @@ impl From<SocketAddr> for Socket<'static> {
         Socket::TcpSocket(addr)
     }
 }
+impl<'a> From<Cow<'a, Path>> for Socket<'a> {
+    fn from(path: Cow<'a, Path>) -> Self {
+        Socket::UnixSocket { path }
+    }
+}
 
 impl Socket<'_> {
     /// Create a new TcpSocket

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -74,6 +74,14 @@ impl From<PathBuf> for Socket<'static> {
     }
 }
 
+impl From<Box<Path>> for Socket<'static> {
+    fn from(path: Box<Path>) -> Self {
+        Socket::UnixSocket {
+            path: Cow::Owned(path.into()),
+        }
+    }
+}
+
 impl Socket<'_> {
     /// Create a new TcpSocket
     pub fn new<T: ToSocketAddrs>(addr: &T) -> Result<Socket<'static>, io::Error> {

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -65,6 +65,7 @@ macro_rules! impl_from_addr {
 
 impl_from_addr!(net::IpAddr);
 impl_from_addr!(net::Ipv4Addr);
+impl_from_addr!(net::Ipv6Addr);
 
 impl<'a> From<Cow<'a, Path>> for Socket<'a> {
     fn from(path: Cow<'a, Path>) -> Self {

--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -56,8 +56,8 @@ impl From<SocketAddr> for Socket<'static> {
 macro_rules! impl_from_addr {
     ($ip:ty) => {
         impl From<($ip, u16)> for Socket<'static> {
-            fn from(addr: ($ip, u16)) -> Self {
-                Socket::new(&addr).unwrap()
+            fn from((ip, port): ($ip, u16)) -> Self {
+                SocketAddr::new(ip.into(), port).into()
             }
         }
     };

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -47,6 +47,8 @@ impl Session {
             .arg(&*self.ctl)
             .arg("-o")
             .arg("BatchMode=yes")
+            .arg("-o")
+            .arg("UpdateHostKeys=no")
             .args(args)
             .arg("none");
         cmd

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -10,23 +10,24 @@ use tokio::process;
 
 use tempfile::TempDir;
 
+/// Session does not have field "addr" because ssh don't care about
+/// the addr as long as we have the ctl.
+/// It is tested on OpenSSH_8.9p1 Ubuntu-3, OpenSSL 3.0.2 15 Mar 2022.
 #[derive(Debug)]
 pub(crate) struct Session {
     tempdir: Option<TempDir>,
     ctl: Box<Path>,
-    addr: Box<str>,
     master_log: Option<Box<Path>>,
 }
 
 impl Session {
-    pub(crate) fn new(tempdir: TempDir, addr: &str) -> Self {
+    pub(crate) fn new(tempdir: TempDir) -> Self {
         let log = tempdir.path().join("log").into_boxed_path();
         let ctl = tempdir.path().join("master").into_boxed_path();
 
         Self {
             tempdir: Some(tempdir),
             ctl,
-            addr: addr.into(),
             master_log: Some(log),
         }
     }
@@ -35,10 +36,6 @@ impl Session {
         Self {
             tempdir: None,
             ctl,
-            // ssh don't care about the addr as long as we have the ctl.
-            //
-            // I tested this behavior on OpenSSH_8.9p1 Ubuntu-3, OpenSSL 3.0.2 15 Mar 2022
-            addr: "none".into(),
             master_log,
         }
     }
@@ -51,7 +48,7 @@ impl Session {
             .arg("-o")
             .arg("BatchMode=yes")
             .args(args)
-            .arg(&*self.addr);
+            .arg("none");
         cmd
     }
 

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -10,9 +10,6 @@ use tokio::process;
 
 use tempfile::TempDir;
 
-/// Session does not have field "addr" because ssh don't care about
-/// the addr as long as we have the ctl.
-/// It is tested on OpenSSH 8.2p1, 8.9p1, 9.0p1
 #[derive(Debug)]
 pub(crate) struct Session {
     tempdir: Option<TempDir>,
@@ -48,6 +45,9 @@ impl Session {
             .arg("-o")
             .arg("BatchMode=yes")
             .args(args)
+            // ssh does not care about the addr as long as we have passed
+            // `-S &*self.ctl`.
+            // It is tested on OpenSSH 8.2p1, 8.9p1, 9.0p1
             .arg("none");
         cmd
     }

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -175,17 +175,13 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) async fn close(mut self) -> Result<(), Error> {
+    pub(crate) async fn close(mut self) -> Result<Option<TempDir>, Error> {
         // Take self.tempdir so that drop would do nothing
-        if let Some(tempdir) = self.tempdir.take() {
-            self.close_impl().await?;
+        let tempdir = self.tempdir.take();
 
-            tempdir.close().map_err(Error::Cleanup)?;
-        } else {
-            self.close_impl().await?;
-        }
+        self.close_impl().await?;
 
-        Ok(())
+        Ok(tempdir)
     }
 
     pub(crate) fn detach(mut self) -> (Box<Path>, Option<Box<Path>>) {

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 
 /// Session does not have field "addr" because ssh don't care about
 /// the addr as long as we have the ctl.
-/// It is tested on OpenSSH_8.9p1 Ubuntu-3, OpenSSL 3.0.2 15 Mar 2022.
+/// It is tested on OpenSSH 8.2p1, 8.9p1, 9.0p1
 #[derive(Debug)]
 pub(crate) struct Session {
     tempdir: Option<TempDir>,

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -18,10 +18,11 @@ pub(crate) struct Session {
     tempdir: Option<TempDir>,
     ctl: Box<Path>,
     master_log: Option<Box<Path>>,
+    addr: Box<str>,
 }
 
 impl Session {
-    pub(crate) fn new(tempdir: TempDir) -> Self {
+    pub(crate) fn new(tempdir: TempDir, addr: Box<str>) -> Self {
         let log = tempdir.path().join("log").into_boxed_path();
         let ctl = tempdir.path().join("master").into_boxed_path();
 
@@ -29,6 +30,7 @@ impl Session {
             tempdir: Some(tempdir),
             ctl,
             master_log: Some(log),
+            addr,
         }
     }
 
@@ -37,6 +39,7 @@ impl Session {
             tempdir: None,
             ctl,
             master_log,
+            addr: "none".into(),
         }
     }
 
@@ -50,7 +53,7 @@ impl Session {
             .arg("-o")
             .arg("UpdateHostKeys=no")
             .args(args)
-            .arg("none");
+            .arg(&*self.addr);
         cmd
     }
 

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -18,11 +18,10 @@ pub(crate) struct Session {
     tempdir: Option<TempDir>,
     ctl: Box<Path>,
     master_log: Option<Box<Path>>,
-    addr: Box<str>,
 }
 
 impl Session {
-    pub(crate) fn new(tempdir: TempDir, addr: Box<str>) -> Self {
+    pub(crate) fn new(tempdir: TempDir) -> Self {
         let log = tempdir.path().join("log").into_boxed_path();
         let ctl = tempdir.path().join("master").into_boxed_path();
 
@@ -30,7 +29,6 @@ impl Session {
             tempdir: Some(tempdir),
             ctl,
             master_log: Some(log),
-            addr,
         }
     }
 
@@ -39,7 +37,6 @@ impl Session {
             tempdir: None,
             ctl,
             master_log,
-            addr: "none".into(),
         }
     }
 
@@ -53,7 +50,7 @@ impl Session {
             .arg("-o")
             .arg("UpdateHostKeys=no")
             .args(args)
-            .arg(&*self.addr);
+            .arg("none");
         cmd
     }
 

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -104,18 +104,18 @@ impl Session {
 
     pub(crate) async fn request_port_forward(
         &self,
-        forward_type: impl Into<ForwardType>,
-        listen_socket: impl Into<Socket<'_>>,
-        connect_socket: impl Into<Socket<'_>>,
+        forward_type: ForwardType,
+        listen_socket: Socket<'_>,
+        connect_socket: Socket<'_>,
     ) -> Result<(), Error> {
-        let flag = match forward_type.into() {
+        let flag = match forward_type {
             ForwardType::Local => OsStr::new("-L"),
             ForwardType::Remote => OsStr::new("-R"),
         };
 
-        let mut forwarding = listen_socket.into().as_os_str().into_owned();
+        let mut forwarding = listen_socket.as_os_str().into_owned();
         forwarding.push(":");
-        forwarding.push(connect_socket.into().as_os_str());
+        forwarding.push(connect_socket.as_os_str());
 
         let port_forwarding = self
             .new_cmd(&[OsStr::new("-fNT"), flag, &*forwarding])

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -47,8 +47,6 @@ impl Session {
             .arg(&*self.ctl)
             .arg("-o")
             .arg("BatchMode=yes")
-            .arg("-o")
-            .arg("UpdateHostKeys=no")
             .args(args)
             .arg("none");
         cmd

--- a/src/session.rs
+++ b/src/session.rs
@@ -260,10 +260,14 @@ impl Session {
     /// # Ok(()) }
     /// ```
     pub fn subsystem<S: AsRef<OsStr>>(&self, program: S) -> Command<'_> {
-        Command::new(
-            self,
-            delegate!(&self.0, imp, { imp.subsystem(program).into() }),
-        )
+        fn inner<'s>(this: &'s Session, program: &OsStr) -> Command<'s> {
+            Command::new(
+                this,
+                delegate!(&this.0, imp, { imp.subsystem(program).into() }),
+            )
+        }
+
+        inner(self, program.as_ref())
     }
 
     /// Constructs a new [`Command`] that runs the provided shell command on the remote host.

--- a/src/session.rs
+++ b/src/session.rs
@@ -362,7 +362,12 @@ impl Session {
     /// This destructor terminates the ssh multiplex server
     /// regardless of how it was created.
     pub async fn close(self) -> Result<(), Error> {
-        delegate!(self.0, imp, { imp.close().await })
+        let res: Result<Option<TempDir>, Error> = delegate!(self.0, imp, { imp.close().await });
+
+        res?.map(TempDir::close)
+            .transpose()
+            .map_err(Error::Cleanup)
+            .map(|_| ())
     }
 
     /// Detach the lifetime of underlying ssh multiplex master

--- a/src/session.rs
+++ b/src/session.rs
@@ -175,7 +175,11 @@ impl Session {
     /// If `program` is not an absolute path, the `PATH` will be searched in an OS-defined way on
     /// the host.
     pub fn command<'a, S: Into<Cow<'a, str>>>(&self, program: S) -> Command<'_> {
-        self.raw_command(&*shell_escape::unix::escape(program.into()))
+        fn inner<'s>(this: &'s Session, program: Cow<'_, str>) -> Command<'s> {
+            this.raw_command(&*shell_escape::unix::escape(program))
+        }
+
+        inner(self, program.into())
     }
 
     /// Constructs a new [`Command`] for launching the program at path `program` on the remote

--- a/src/session.rs
+++ b/src/session.rs
@@ -320,25 +320,14 @@ impl Session {
         listen_socket: impl Into<Socket<'_>>,
         connect_socket: impl Into<Socket<'_>>,
     ) -> Result<(), Error> {
-        async fn inner(
-            this: &Session,
-            forward_type: ForwardType,
-            listen_socket: Socket<'_>,
-            connect_socket: Socket<'_>,
-        ) -> Result<(), Error> {
-            delegate!(&this.0, imp, {
-                imp.request_port_forward(forward_type, listen_socket, connect_socket)
-                    .await
-            })
-        }
-
-        inner(
-            self,
-            forward_type.into(),
-            listen_socket.into(),
-            connect_socket.into(),
-        )
-        .await
+        delegate!(&self.0, imp, {
+            imp.request_port_forward(
+                forward_type.into().into(),
+                listen_socket.into().into(),
+                connect_socket.into().into(),
+            )
+            .await
+        })
     }
 
     /// Terminate the remote connection.

--- a/src/session.rs
+++ b/src/session.rs
@@ -108,7 +108,10 @@ impl Session {
     #[cfg(feature = "process-mux")]
     #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub async fn connect<S: AsRef<str>>(destination: S, check: KnownHosts) -> Result<Self, Error> {
-        Self::connect_impl(destination.as_ref(), check, Session::new_process_mux).await
+        SessionBuilder::default()
+            .known_hosts_check(check)
+            .connect(destination)
+            .await
     }
 
     /// Connect to the host at the given `host` over SSH using native mux impl, which
@@ -130,17 +133,10 @@ impl Session {
         destination: S,
         check: KnownHosts,
     ) -> Result<Self, Error> {
-        Self::connect_impl(destination.as_ref(), check, Session::new_native_mux).await
-    }
-
-    async fn connect_impl(
-        destination: &str,
-        check: KnownHosts,
-        f: fn(TempDir) -> Session,
-    ) -> Result<Self, Error> {
-        let mut s = SessionBuilder::default();
-        s.known_hosts_check(check);
-        s.connect_impl(destination, f).await
+        SessionBuilder::default()
+            .known_hosts_check(check)
+            .connect_mux(destination)
+            .await
     }
 
     /// Check the status of the underlying SSH connection.

--- a/src/session.rs
+++ b/src/session.rs
@@ -54,15 +54,12 @@ pub struct Session(SessionImp);
 
 impl Session {
     #[cfg(feature = "process-mux")]
-    pub(super) fn new_process_mux(tempdir: TempDir, addr: &str) -> Self {
-        Self(SessionImp::ProcessImpl(process_impl::Session::new(
-            tempdir,
-            addr.into(),
-        )))
+    pub(super) fn new_process_mux(tempdir: TempDir) -> Self {
+        Self(SessionImp::ProcessImpl(process_impl::Session::new(tempdir)))
     }
 
     #[cfg(feature = "native-mux")]
-    pub(super) fn new_native_mux(tempdir: TempDir, _addr: &str) -> Self {
+    pub(super) fn new_native_mux(tempdir: TempDir) -> Self {
         Self(SessionImp::NativeMuxImpl(native_mux_impl::Session::new(
             tempdir,
         )))
@@ -139,7 +136,7 @@ impl Session {
     async fn connect_impl(
         destination: &str,
         check: KnownHosts,
-        f: fn(TempDir, &str) -> Session,
+        f: fn(TempDir) -> Session,
     ) -> Result<Self, Error> {
         let mut s = SessionBuilder::default();
         s.known_hosts_check(check);

--- a/src/session.rs
+++ b/src/session.rs
@@ -199,10 +199,14 @@ impl Session {
     /// If `program` is not an absolute path, the `PATH` will be searched in an OS-defined way on
     /// the host.
     pub fn raw_command<S: AsRef<OsStr>>(&self, program: S) -> Command<'_> {
-        Command::new(
-            self,
-            delegate!(&self.0, imp, { imp.raw_command(program).into() }),
-        )
+        fn inner<'s>(this: &'s Session, program: &OsStr) -> Command<'s> {
+            Command::new(
+                this,
+                delegate!(&this.0, imp, { imp.raw_command(program).into() }),
+            )
+        }
+
+        inner(self, program.as_ref())
     }
 
     /// Constructs a new [`Command`] for launching subsystem `program` on the remote

--- a/src/session.rs
+++ b/src/session.rs
@@ -310,9 +310,13 @@ impl Session {
     ///   [this article]: https://mywiki.wooledge.org/Arguments
     ///   [`shell-escape`]: https://crates.io/crates/shell-escape
     pub fn shell<S: AsRef<str>>(&self, command: S) -> Command<'_> {
-        let mut cmd = self.command("sh");
-        cmd.arg("-c").arg(command);
-        cmd
+        fn inner<'s>(this: &'s Session, command: &str) -> Command<'s> {
+            let mut cmd = this.command("sh");
+            cmd.arg("-c").arg(command);
+            cmd
+        }
+
+        inner(self, command.as_ref())
     }
 
     /// Request to open a local/remote port forwarding.

--- a/src/session.rs
+++ b/src/session.rs
@@ -175,11 +175,7 @@ impl Session {
     /// If `program` is not an absolute path, the `PATH` will be searched in an OS-defined way on
     /// the host.
     pub fn command<'a, S: Into<Cow<'a, str>>>(&self, program: S) -> Command<'_> {
-        fn inner<'s>(this: &'s Session, program: Cow<'_, str>) -> Command<'s> {
-            this.raw_command(&*shell_escape::unix::escape(program))
-        }
-
-        inner(self, program.into())
+        self.raw_command(&*shell_escape::unix::escape(program.into()))
     }
 
     /// Constructs a new [`Command`] for launching the program at path `program` on the remote
@@ -199,14 +195,10 @@ impl Session {
     /// If `program` is not an absolute path, the `PATH` will be searched in an OS-defined way on
     /// the host.
     pub fn raw_command<S: AsRef<OsStr>>(&self, program: S) -> Command<'_> {
-        fn inner<'s>(this: &'s Session, program: &OsStr) -> Command<'s> {
-            Command::new(
-                this,
-                delegate!(&this.0, imp, { imp.raw_command(program).into() }),
-            )
-        }
-
-        inner(self, program.as_ref())
+        Command::new(
+            self,
+            delegate!(&self.0, imp, { imp.raw_command(program.as_ref()).into() }),
+        )
     }
 
     /// Constructs a new [`Command`] for launching subsystem `program` on the remote
@@ -260,14 +252,10 @@ impl Session {
     /// # Ok(()) }
     /// ```
     pub fn subsystem<S: AsRef<OsStr>>(&self, program: S) -> Command<'_> {
-        fn inner<'s>(this: &'s Session, program: &OsStr) -> Command<'s> {
-            Command::new(
-                this,
-                delegate!(&this.0, imp, { imp.subsystem(program).into() }),
-            )
-        }
-
-        inner(self, program.as_ref())
+        Command::new(
+            self,
+            delegate!(&self.0, imp, { imp.subsystem(program.as_ref()).into() }),
+        )
     }
 
     /// Constructs a new [`Command`] that runs the provided shell command on the remote host.
@@ -310,13 +298,9 @@ impl Session {
     ///   [this article]: https://mywiki.wooledge.org/Arguments
     ///   [`shell-escape`]: https://crates.io/crates/shell-escape
     pub fn shell<S: AsRef<str>>(&self, command: S) -> Command<'_> {
-        fn inner<'s>(this: &'s Session, command: &str) -> Command<'s> {
-            let mut cmd = this.command("sh");
-            cmd.arg("-c").arg(command);
-            cmd
-        }
-
-        inner(self, command.as_ref())
+        let mut cmd = self.command("sh");
+        cmd.arg("-c").arg(command.as_ref());
+        cmd
     }
 
     /// Request to open a local/remote port forwarding.

--- a/src/session.rs
+++ b/src/session.rs
@@ -54,12 +54,15 @@ pub struct Session(SessionImp);
 
 impl Session {
     #[cfg(feature = "process-mux")]
-    pub(super) fn new_process_mux(tempdir: TempDir) -> Self {
-        Self(SessionImp::ProcessImpl(process_impl::Session::new(tempdir)))
+    pub(super) fn new_process_mux(tempdir: TempDir, addr: &str) -> Self {
+        Self(SessionImp::ProcessImpl(process_impl::Session::new(
+            tempdir,
+            addr.into(),
+        )))
     }
 
     #[cfg(feature = "native-mux")]
-    pub(super) fn new_native_mux(tempdir: TempDir) -> Self {
+    pub(super) fn new_native_mux(tempdir: TempDir, _addr: &str) -> Self {
         Self(SessionImp::NativeMuxImpl(native_mux_impl::Session::new(
             tempdir,
         )))
@@ -136,7 +139,7 @@ impl Session {
     async fn connect_impl(
         destination: &str,
         check: KnownHosts,
-        f: fn(TempDir) -> Session,
+        f: fn(TempDir, &str) -> Session,
     ) -> Result<Self, Error> {
         let mut s = SessionBuilder::default();
         s.known_hosts_check(check);

--- a/src/session.rs
+++ b/src/session.rs
@@ -322,9 +322,9 @@ impl Session {
     ) -> Result<(), Error> {
         delegate!(&self.0, imp, {
             imp.request_port_forward(
-                forward_type.into().into(),
-                listen_socket.into().into(),
-                connect_socket.into().into(),
+                forward_type.into(),
+                listen_socket.into(),
+                connect_socket.into(),
             )
             .await
         })

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -1,10 +1,9 @@
 use lazy_static::lazy_static;
 use regex::Regex;
-use std::borrow::Cow;
 use std::env;
 use std::io;
 use std::io::Write;
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 use tempfile::tempdir;

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -733,10 +733,8 @@ async fn remote_socket_forward() {
         session
             .request_port_forward(
                 ForwardType::Remote,
-                Socket::TcpSocket(SocketAddr::new(loopback(), *port)),
-                Socket::UnixSocket {
-                    path: Cow::Borrowed(&unix_socket),
-                },
+                SocketAddr::new(loopback(), *port),
+                Cow::Borrowed(&*unix_socket),
             )
             .await
             .unwrap();

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -731,11 +731,7 @@ async fn remote_socket_forward() {
 
         eprintln!("Requesting port forward");
         session
-            .request_port_forward(
-                ForwardType::Remote,
-                SocketAddr::new(loopback(), *port),
-                Cow::Borrowed(&*unix_socket),
-            )
+            .request_port_forward(ForwardType::Remote, (loopback(), *port), &*unix_socket)
             .await
             .unwrap();
 
@@ -797,13 +793,7 @@ async fn local_socket_forward() {
         let unix_socket = dir.path().join("unix_socket_forwarded");
 
         session
-            .request_port_forward(
-                ForwardType::Local,
-                Socket::UnixSocket {
-                    path: Cow::Borrowed(&unix_socket),
-                },
-                Socket::TcpSocket(SocketAddr::new(loopback(), port)),
-            )
+            .request_port_forward(ForwardType::Local, &*unix_socket, (loopback(), port))
             .await
             .unwrap();
 


### PR DESCRIPTION
 - Avoid dup monomorphization.
 - Rm field `addr` in `process_impl::Session`
 - Take `impl Into<...>` in `Session::request_port_forwarding`
 - Implement `From<...> for Socket`
 -  Optimize Session::close: Avoid dup code
    - Avoid duplicate call to `close_impl` in both `process_impl` and
      `native_mux_impl`
    - Extract out code to close `TempDir` out into `Session::close`


Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>