### PR TITLE
Use Rust 1.63's `OwnedFd`

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56.1
+          toolchain: 1.63.0
           override: true
       - uses: actions/checkout@v2
-      - name: cargo +1.56.1 check
+      - name: cargo +1.63.0 check
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,6 +29,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           components: rustfmt, clippy
+          override: true
       - uses: actions/checkout@v2
       - name: cargo fmt --check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
+          override: true
       - uses: actions/checkout@v2
       - run: |
           # Wait for startup of openssh-server

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
 tokio-pipe = "0.2.8"
 
 libc = "0.2.112"
-io-lifetimes = "0.7"
 
 once_cell = "1.8.0"
 dirs = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,6 @@ thiserror = "1.0.30"
 tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
 tokio-pipe = "0.2.8"
 
-libc = "0.2.112"
-
 once_cell = "1.8.0"
 dirs = "4.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "openssh"
 version = "0.9.6"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.63.0"
 license = "MIT OR Apache-2.0"
 
 readme = "README.md"

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -33,8 +33,7 @@ pub mod v0_9_5 {}
 /// ## Added
 ///  - [`Session::resume`]
 ///  - [`Session::resume_mux`]
-///  - [`Session::leak`]
-///  - [`Session::force_terminate`]
+///  - [`Session::detach`]
 pub mod v0_9_3 {}
 
 /// ## Changed

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -4,6 +4,7 @@ use crate::*;
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
 ///
 /// ## Added
+///  - `impl From<std::os::unix::io::OwnedFd> for Stdio`
 /// ## Changed
 /// ## Removed
 #[doc(hidden)]

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -3,9 +3,9 @@ use super::Error;
 #[cfg(feature = "native-mux")]
 use super::native_mux_impl;
 
-use io_lifetimes::OwnedFd;
 use std::fs::File;
 use std::io;
+use std::os::unix::io::OwnedFd;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::pin::Pin;
 use std::process;

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -12,16 +12,6 @@ use std::process;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-pub(crate) unsafe fn dup(raw_fd: RawFd) -> Result<OwnedFd, Error> {
-    let res = libc::dup(raw_fd);
-    if res == -1 {
-        Err(Error::ChildIo(io::Error::last_os_error()))
-    } else {
-        // safety: dup returns a valid fd on success.
-        Ok(OwnedFd::from_raw_fd(res))
-    }
-}
-
 #[derive(Debug)]
 pub(crate) enum StdioImpl {
     /// Read/Write to /dev/null

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -65,6 +65,12 @@ impl From<Stdio> for process::Stdio {
     }
 }
 
+impl From<OwnedFd> for Stdio {
+    fn from(fd: OwnedFd) -> Self {
+        Self(StdioImpl::Fd(fd))
+    }
+}
+
 macro_rules! impl_from_for_stdio {
     ($type:ty) => {
         impl From<$type> for Stdio {

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -5,8 +5,7 @@ use super::native_mux_impl;
 
 use std::fs::File;
 use std::io;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-use std::os::unix::io::{BorrowedFd, OwnedFd};
+use std::os::unix::io::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::pin::Pin;
 use std::process;
 use std::task::{Context, Poll};


### PR DESCRIPTION
 - Bump msrv to 1.63
 - Remove dep `io_lifetimes` and `libc`
 - Add back `impl From<std::os::unix::io::OwnedFd> for Stdio`