### PR TITLE
Bump dep openssh-mux-client to v0.15.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tokio-pipe = "0.2.8"
 once_cell = "1.8.0"
 dirs = "4.0.0"
 
-openssh-mux-client = { version = "0.15.0", optional = true }
+openssh-mux-client = { version = "0.15.1", optional = true }
 
 [dev-dependencies]
 regex = "1"


### PR DESCRIPTION
that fixed the dep on yanked tokio-io-utility v0.6.4

Fix #98 

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>