### PR TITLE
Fixed stdout/stderr cut off bug when using `RemoteChild::wait_with_output`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ dirs = "4.0.0"
 
 openssh-mux-client = { version = "0.15.1", optional = true }
 
+libc = "0.2.137"
+
 [dev-dependencies]
 regex = "1"
 tokio = { version = "1", features = [ "full" ] }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -5,7 +5,13 @@ use crate::*;
 ///
 /// ## Added
 ///  - `impl From<std::os::unix::io::OwnedFd> for Stdio`
+///  -  Add new fn `Stdio::from_raw_fd_owned`
 /// ## Changed
+///  - Mark `FromRawFd` impl for `Stdio` as deprecated
+///  - Mark `From<tokio_pipe::PipeRead>` for `Stdio` as deprecated
+///  - Mark `From<tokio_pipe::PipeWrite>` for `Stdio` as deprecated
+/// ## Fixed
+///  - [`wait_with_output` + `native-mux` cuts off stdout output](https://github.com/openssh-rust/openssh/issues/103)
 /// ## Removed
 #[doc(hidden)]
 pub mod unreleased {}

--- a/src/child.rs
+++ b/src/child.rs
@@ -175,8 +175,8 @@ impl<'s> RemoteChild<'s> {
         let (stdout, stderr) = try_join!(stdout_read, stderr_read)?;
         Ok(Output {
             // Once self.wait().await is done, the connection to the multiplex
-            // server would also be dropped and the server would stop
-            // sending data to stdout/stderr.
+            // server will also be dropped and the server will stop sending
+            // data to stdout/stderr.
             status: self.wait().await?,
             stdout,
             stderr,

--- a/src/child.rs
+++ b/src/child.rs
@@ -63,7 +63,7 @@ macro_rules! delegate {
 /// [`Command`](crate::Command).
 ///
 /// NOTE that once `RemoteChild` is dropped, any data written to `stdin` will not be sent to the
-/// remote process and `stdout` and `stderr` would eof immediately.
+/// remote process and `stdout` and `stderr` will yield EOF immediately.
 ///
 /// ```rust,no_run
 /// # async fn foo() {

--- a/src/child.rs
+++ b/src/child.rs
@@ -62,7 +62,7 @@ macro_rules! delegate {
 /// available,`Stdio::piped()` should be passed to the corresponding method on
 /// [`Command`](crate::Command).
 ///
-/// NOTE that once `RemoteChild` is dropped, any data written to `stdin` will not be send to the
+/// NOTE that once `RemoteChild` is dropped, any data written to `stdin` will not be sent to the
 /// remote process and `stdout` and `stderr` would eof immediately.
 ///
 /// ```rust,no_run

--- a/src/child.rs
+++ b/src/child.rs
@@ -62,6 +62,9 @@ macro_rules! delegate {
 /// available,`Stdio::piped()` should be passed to the corresponding method on
 /// [`Command`](crate::Command).
 ///
+/// NOTE that once `RemoteChild` is dropped, any data written to `stdin` will not be send to the
+/// remote process and `stdout` and `stderr` would eof immediately.
+///
 /// ```rust,no_run
 /// # async fn foo() {
 /// # let child: openssh::RemoteChild<'static> = unimplemented!();

--- a/src/child.rs
+++ b/src/child.rs
@@ -174,9 +174,12 @@ impl<'s> RemoteChild<'s> {
         // and cause the remote process to block forever.
         let (stdout, stderr) = try_join!(stdout_read, stderr_read)?;
         Ok(Output {
-            // Once self.wait().await is done, the connection to the multiplex
-            // server will also be dropped and the server will stop sending
-            // data to stdout/stderr.
+            // The self.wait() future terminates the stdout and stderr futures
+            // when it resolves, even if there may still be more data arriving
+            // from the server.
+            //
+            // Therefore, we wait for them first, and only once they're complete
+            // do we wait for the process to have terminated.
             status: self.wait().await?,
             stdout,
             stderr,

--- a/src/child.rs
+++ b/src/child.rs
@@ -169,9 +169,12 @@ impl<'s> RemoteChild<'s> {
 
         // Execute them concurrently to avoid the pipe buffer being filled up
         // and cause the remote process to block forever.
-        let (status, stdout, stderr) = try_join!(self.wait(), stdout_read, stderr_read)?;
+        let (stdout, stderr) = try_join!(stdout_read, stderr_read)?;
         Ok(Output {
-            status,
+            // Once self.wait().await is done, the connection to the multiplex
+            // server would also be dropped and the server would stop
+            // sending data to stdout/stderr.
+            status: self.wait().await?,
             stdout,
             stderr,
         })

--- a/src/native_mux_impl/command.rs
+++ b/src/native_mux_impl/command.rs
@@ -1,6 +1,6 @@
 use super::Error;
 use super::RemoteChild;
-use super::{ChildStderr, ChildStdin, ChildStdout, Stdio};
+use super::{stdio::set_blocking, ChildStderr, ChildStdin, ChildStdout, Stdio};
 
 use std::borrow::Cow;
 use std::ffi::OsStr;
@@ -70,6 +70,10 @@ impl Command {
             stdout.as_raw_fd_or_null_fd()?,
             stderr.as_raw_fd_or_null_fd()?,
         ];
+
+        for stdio in stdios {
+            set_blocking(stdio).map_err(Error::ChildIo)?;
+        }
 
         let cmd = NonZeroByteSlice::new(&self.cmd).ok_or(Error::InvalidCommand)?;
 

--- a/src/native_mux_impl/stdio.rs
+++ b/src/native_mux_impl/stdio.rs
@@ -68,6 +68,10 @@ impl Fd {
         }
     }
 
+    /// # Safety
+    ///
+    /// `T::into_raw_fd` must return a valid fd and transfers
+    /// the ownershipt of it.
     unsafe fn new_owned<T: IntoRawFd>(fd: T) -> Self {
         let raw_fd = fd.into_raw_fd();
         Fd::Owned(OwnedFd::from_raw_fd(raw_fd))

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -108,10 +108,27 @@ macro_rules! impl_from_for_stdio {
             }
         }
     };
+    (deprecated $type:ty) => {
+        #[allow(useless_deprecated)]
+        #[deprecated(
+            since = "0.9.8",
+            note = "Use From<OwnedFd> for Stdio or Stdio::from_raw_fd_owned instead"
+        )]
+        /// deprecated, use `From<OwnedFd> for Stdio` or
+        /// [`Stdio::from_raw_fd_owned`] instead.
+        impl From<$type> for Stdio {
+            fn from(arg: $type) -> Self {
+                let fd = arg.into_raw_fd();
+                // safety: $type must have a valid into_raw_fd implementation
+                // and must not be RawFd.
+                Self(StdioImpl::Fd(unsafe { OwnedFd::from_raw_fd(fd) }, true))
+            }
+        }
+    };
 }
 
-impl_from_for_stdio!(tokio_pipe::PipeWrite);
-impl_from_for_stdio!(tokio_pipe::PipeRead);
+impl_from_for_stdio!(deprecated tokio_pipe::PipeWrite);
+impl_from_for_stdio!(deprecated tokio_pipe::PipeRead);
 
 impl_from_for_stdio!(process::ChildStdin);
 impl_from_for_stdio!(process::ChildStdout);

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -61,6 +61,8 @@ impl Stdio {
         Self(StdioImpl::Fd(OwnedFd::from_raw_fd(fd), true))
     }
 }
+/// **Deprecated, use [`Stdio::from_raw_fd_owned`] instead.**
+///
 /// FromRawFd takes ownership of the fd passed in
 /// and closes the fd on drop.
 ///
@@ -114,8 +116,8 @@ macro_rules! impl_from_for_stdio {
             since = "0.9.8",
             note = "Use From<OwnedFd> for Stdio or Stdio::from_raw_fd_owned instead"
         )]
-        /// deprecated, use `From<OwnedFd> for Stdio` or
-        /// [`Stdio::from_raw_fd_owned`] instead.
+        /// **Deprecated, use `From<OwnedFd> for Stdio` or
+        /// [`Stdio::from_raw_fd_owned`] instead.**
         impl From<$type> for Stdio {
             fn from(arg: $type) -> Self {
                 let fd = arg.into_raw_fd();

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -47,6 +47,19 @@ impl Stdio {
     pub const fn inherit() -> Self {
         Self(StdioImpl::Inherit)
     }
+
+    /// `Stdio::from_raw_fd_owned` takes ownership of the fd passed in
+    /// and closes the fd on drop.
+    ///
+    /// NOTE that the fd will be put into blocking mode, then it will be
+    /// closed when `Stdio` is dropped.
+    ///
+    /// # Safety
+    ///
+    /// * `fd` - must be a valid fd and must give its ownership to `Stdio`.
+    pub unsafe fn from_raw_fd_owned(fd: RawFd) -> Self {
+        Self(StdioImpl::Fd(OwnedFd::from_raw_fd(fd), true))
+    }
 }
 /// FromRawFd takes ownership of the fd passed in
 /// and closes the fd on drop.

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -67,6 +67,8 @@ impl Stdio {
 /// NOTE that the fd must be in blocking mode, otherwise
 /// ssh might not flush all output since it considers
 /// (`EAGAIN`/`EWOULDBLOCK`) as an error
+#[allow(useless_deprecated)]
+#[deprecated(since = "0.9.8", note = "Use Stdio::from_raw_fd_owned instead")]
 impl FromRawFd for Stdio {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Self(StdioImpl::Fd(OwnedFd::from_raw_fd(fd), false))

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -43,6 +43,11 @@ impl Stdio {
     pub const fn inherit() -> Self {
         Self(StdioImpl::Inherit)
     }
+
+    #[cfg(feature = "native-mux")]
+    pub(super) fn is_inherited(&self) -> bool {
+        matches!(self.0, StdioImpl::Inherit)
+    }
 }
 impl FromRawFd for Stdio {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -962,7 +962,7 @@ async fn test_read_large_file_bug() {
 
         assert!(status.success());
 
-        assert_eq!(stdout.len(), bs * count);
         stdout.iter().copied().for_each(|byte| assert_eq!(byte, 0));
+        assert_eq!(stdout.len(), bs * count);
     }
 }

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -2,14 +2,13 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use std::{
     env,
-    io::{self, Read, Write},
+    io::{self, Write},
     net::IpAddr,
-    os::unix::io::AsFd,
     path::PathBuf,
     process,
     time::Duration,
 };
-use tempfile::{tempdir, tempfile};
+use tempfile::tempdir;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{UnixListener, UnixStream},

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -974,34 +974,3 @@ async fn test_read_large_file_bug() {
         assert_eq!(stdout.len(), bs * count);
     }
 }
-
-#[tokio::test]
-#[cfg_attr(not(ci), ignore)]
-async fn test_read_large_file_bug2() {
-    for (session, name) in connects_with_name().await {
-        eprintln!("Testing {name} implementation");
-
-        let bs = 1024;
-        let count = 20480;
-
-        let file = tempfile().unwrap();
-
-        let status = session
-            .shell(format!("dd if=/dev/zero bs={bs} count={count}"))
-            .stdout(Stdio::from(file.as_fd().try_clone_to_owned().unwrap()))
-            .spawn()
-            .await
-            .unwrap()
-            .wait()
-            .await
-            .unwrap();
-
-        assert!(status.success());
-
-        let mut stdout = Vec::with_capacity(bs * count);
-        (&file).read_to_end(&mut stdout).unwrap();
-
-        stdout.iter().copied().for_each(|byte| assert_eq!(byte, 0));
-        assert_eq!(stdout.len(), bs * count);
-    }
-}


### PR DESCRIPTION
Fixed #103 

This PR fixed two bugs:
 - Fix `Fd::as_raw_fd_or_null_fd` in native-mux: Disable non-blocking on all fds before passing them to the ssh multiplex server
 - Fix `RemoteChild::wait_with_output`: Await on `self.wait()` after stdout/stderr is fully read in, otherwise the ssh multiplex server would stop writing data to stdout/stderr once `self.wait()` is done (which drops the connection to the server)

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>