### PR TITLE
Allow conversion of `std::process::Command` into a `openssh::Command` given a `openssh::Session`.

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -94,7 +94,7 @@ impl OverSsh for std::process::Command {
         
         let args = self
             .get_args()
-            .map(|arg| escape(arg));
+            .map(escape);
         command.raw_args(args);
         command
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -103,9 +103,10 @@ pub trait OverSsh {
     ///     let session = Session::connect_mux("me@ssh.example.com", KnownHosts::Strict).await?;
     ///     let echo =
     ///         Command::new("echo")
+    ///         .env("MY_ENV_VAR", "foo")
     ///         .arg("$MY_ENV_VAR")
     ///         .over_ssh(&session);
-    ///     assert_matches!(echo, Err(openssh::Error::CommandHasEnv));
+    ///     assert!(matches!(echo, Err(openssh::Error::CommandHasEnv)));
     ///
     /// #   Ok(())
     /// }

--- a/src/command.rs
+++ b/src/command.rs
@@ -71,7 +71,7 @@ impl OverSsh for std::process::Command {
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     use std::process::Command;
     ///     use openssh::{Session, KnownHosts, OverSsh};
-
+    ///
     ///     let session = Session::connect_mux("me@ssh.example.com", KnownHosts::Strict).await?;
     ///     let ls = 
     ///         Command::new("ls")

--- a/src/command.rs
+++ b/src/command.rs
@@ -59,6 +59,23 @@ pub trait OverSsh {
 impl OverSsh for std::process::Command {
     /// Given a session, convert a std::process::Command into an `openssh::Command` 
     /// that can be executed over that session.
+    /// ```no_run
+    /// use std::process::Command;
+    /// use openssh::{Session, KnownHosts, OverSsh};
+
+    /// let session = Session::connect_mux("me@ssh.example.com", KnownHosts::Strict).await?;
+    /// let ls = 
+    ///     Command::new("ls")
+    ///     .arg("-l")
+    ///     .arg("-a")
+    ///     .arg("-h")
+    ///     .with_session(&session)
+    ///     .output()
+    ///     .await?;
+    /// assert!(String::from_utf8(ls.stdout).unwrap().contains("total"));
+    /// 
+    /// 
+    /// ```
     fn with_session<'session>(&self, session: &'session Session) -> Result<Command<'session>, Error> {
         let program = 
             self

--- a/src/command.rs
+++ b/src/command.rs
@@ -57,7 +57,7 @@ pub trait OverSsh {
 }
 
 impl OverSsh for std::process::Command {
-    /// Given a session, convert a std::process::Command into an `openssh::Command` 
+    /// Given a session, convert a `std::process::Command` into an `openssh::Command` 
     /// that can be executed over that session.
     /// ```no_run
     /// use std::process::Command;

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,11 +34,6 @@ pub enum Error {
     #[error("the remote command could not be executed")]
     Remote(#[source] io::Error),
 
-    /// Invalid UTF-8 string when trying to
-    /// convert a `std::ffi::OsString` to a `String`.
-    #[error("invalid string")]
-    InvalidUtf8String(std::ffi::OsString),
-
     /// The connection to the remote host was severed.
     ///
     /// Note that for the process impl, this is a best-effort error, and it _may_ instead

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,11 @@ pub enum Error {
     #[error("the remote command could not be executed")]
     Remote(#[source] io::Error),
 
+    /// Invalid UTF-8 string when trying to
+    /// convert a `std::ffi::OsString` to a `String`.
+    #[error("invalid string")]
+    InvalidUtf8String(std::ffi::OsString),
+
     /// The connection to the remote host was severed.
     ///
     /// Note that for the process impl, this is a best-effort error, and it _may_ instead

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,6 +67,16 @@ pub enum Error {
     /// IO Error when creating/reading/writing from ChildStdin, ChildStdout, ChildStderr.
     #[error("failure while accessing standard i/o of remote process")]
     ChildIo(#[source] io::Error),
+
+    /// The command has some env variables that it expects to carry over ssh.
+    /// However, OverSsh does not support passing env variables over ssh.
+    #[error("rejected runing a command over ssh that expects env variables to be carried over to remote.")]
+    CommandHasEnv,
+
+    /// The command expects to be in a specific working directory in remote.
+    /// However, OverSsh does not support setting a working directory for commands to be executed over ssh.
+    #[error("rejected runing a command over ssh that expects a specific working directory to be carried over to remote.")]
+    CommandHasCwd,
 }
 
 #[cfg(feature = "native-mux")]

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -28,18 +28,18 @@ fn whitelisted(byte: u8) -> bool {
 /// [`shell-escape::unix::escape`]: https://docs.rs/shell-escape/latest/src/shell_escape/lib.rs.html#101
 /// 
 pub fn escape(s: &OsStr) -> Cow<'_, OsStr> {
-    let s = s.as_bytes();
-    let all_whitelisted = s.iter().copied().all(whitelisted);
+    let as_bytes = s.as_bytes();
+    let all_whitelisted = as_bytes.iter().copied().all(whitelisted);
 
-    if !s.is_empty() && all_whitelisted {
+    if !as_bytes.is_empty() && all_whitelisted {
         return Cow::Borrowed(s);
     }
 
-    let mut escaped = Vec::with_capacity(s.len() + 2);
+    let mut escaped = Vec::with_capacity(as_bytes.len() + 2);
     escaped.reserve(4);
     escaped.push(b'\'');
 
-    for &b in s {
+    for &b in as_bytes {
         match b {
             b'\'' | b'!' => {
                 escaped.push(b'\'');

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -11,7 +11,7 @@ use std::{
     os::unix::ffi::OsStringExt,
 };
 
-fn whitelisted(byte: u8) -> bool {
+fn allowed(byte: u8) -> bool {
     matches!(byte, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'=' | b'/' | b',' | b'.' | b'+')
 }
 
@@ -25,9 +25,9 @@ fn whitelisted(byte: u8) -> bool {
 ///
 pub(crate) fn escape(s: &OsStr) -> Cow<'_, OsStr> {
     let as_bytes = s.as_bytes();
-    let all_whitelisted = as_bytes.iter().copied().all(whitelisted);
+    let all_allowed = as_bytes.iter().copied().all(allowed);
 
-    if !as_bytes.is_empty() && all_whitelisted {
+    if !as_bytes.is_empty() && all_allowed {
         return Cow::Borrowed(s);
     }
 
@@ -81,6 +81,7 @@ mod tests {
         test_escape_case(r#"'!\$`\\\n "#, r#"''\'''\!'\$`\\\n '"#);
         test_escape_case("", r#"''"#);
         test_escape_case(" ", r#"' '"#);
+        test_escape_case("*", r#"'*'"#);
 
         test_escape_from_bytes(
             &[0x66, 0x6f, 0x80, 0x6f],

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -32,7 +32,6 @@ pub(crate) fn escape(s: &OsStr) -> Cow<'_, OsStr> {
     }
 
     let mut escaped = Vec::with_capacity(as_bytes.len() + 2);
-    escaped.reserve(4);
     escaped.push(b'\'');
 
     for &b in as_bytes {

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -13,10 +13,7 @@ use std::{
 
 
 fn whitelisted(byte: u8) -> bool {
-    match byte {
-        b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'=' | b'/' | b',' | b'.' | b'+' => true,
-        _ => false,
-    }
+    matches!(byte, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'=' | b'/' | b',' | b'.' | b'+')
 }
 
 /// Escape characters that may have special meaning in a shell, including spaces.
@@ -27,7 +24,7 @@ fn whitelisted(byte: u8) -> bool {
 /// 
 /// [`shell-escape::unix::escape`]: https://docs.rs/shell-escape/latest/src/shell_escape/lib.rs.html#101
 /// 
-pub fn escape(s: &OsStr) -> Cow<'_, OsStr> {
+pub(crate) fn escape(s: &OsStr) -> Cow<'_, OsStr> {
     let as_bytes = s.as_bytes();
     let all_whitelisted = as_bytes.iter().copied().all(whitelisted);
 

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -29,7 +29,7 @@ fn whitelisted(byte: u8) -> bool {
 /// 
 pub fn escape(s: &OsStr) -> Cow<'_, OsStr> {
     let s = s.as_bytes();
-    let all_whitelisted = s.iter().all(|x| whitelisted(*x));
+    let all_whitelisted = s.iter().copied().all(whitelisted);
 
     if !s.is_empty() && all_whitelisted {
         return OsString::from_vec(s.to_vec()).into();

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,0 +1,81 @@
+//! Escape characters that may have special meaning in a shell, including spaces.
+//! This is a modified version of the [`shell-escape::unix`] module of [`shell-escape`] crate.
+//! 
+//! [`shell-escape`]: https://crates.io/crates/shell-escape
+//! [`shell-escape::unix`]: https://docs.rs/shell-escape/latest/src/shell_escape/lib.rs.html#101
+
+
+fn whitelisted(ch: char) -> bool {
+    match ch {
+        'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '=' | '/' | ',' | '.' | '+' => true,
+        _ => false,
+    }
+}
+
+/// Escape characters that may have special meaning in a shell, including spaces.
+/// 
+/// **Note**: This function is an adaptation of [`shell-escape::unix::escape`].
+/// This function exists only for type compatibility and the implementation is
+/// almost exactly the same as [`shell-escape::unix::escape`].
+/// 
+/// [`shell-escape::unix::escape`]: https://docs.rs/shell-escape/latest/src/shell_escape/lib.rs.html#101
+/// 
+pub fn escape(s: &[u8]) -> String {
+    let all_whitelisted = s.iter().all(|x| whitelisted(*x as char));
+
+    if !s.is_empty() && all_whitelisted {
+        // All bytes are whitelisted and valid single-byte UTF-8, 
+        // so we can build the original string and return as is.
+        return String::from_utf8(s.to_vec()).unwrap();
+    }
+
+    let mut escaped = String::with_capacity(s.len() + 2);
+    escaped.push('\'');
+
+    for &b in s {
+        match b {
+            b'\'' | b'!' => {
+                escaped.push_str("'\\");
+                escaped.push(b as char);
+                escaped.push('\'');
+            }
+            _ => escaped.push(b as char),
+        }
+    }
+    escaped.push('\'');
+    escaped
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests are courtesy of the `shell-escape` crate.
+    #[test]
+    fn test_escape() {
+        assert_eq!(
+            escape(b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=/,.+"), 
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=/,.+"
+        );
+        assert_eq!(
+            escape(b"--aaa=bbb-ccc"), 
+            "--aaa=bbb-ccc"
+        );
+        assert_eq!(
+            escape(b"linker=gcc -L/foo -Wl,bar"), 
+            r#"'linker=gcc -L/foo -Wl,bar'"#
+        );
+        assert_eq!(
+            escape(br#"--features="default""#), 
+            r#"'--features="default"'"#
+        );
+        assert_eq!(
+            escape(br#"'!\$`\\\n "#), 
+            r#"''\'''\!'\$`\\\n '"#
+        );
+        assert_eq!(escape(b""), r#"''"#);
+        assert_eq!(escape(b" "), r#"' '"#);
+        assert_eq!(escape(b"\xC4b"), r#"'Äb'"#);
+    }
+}

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -55,10 +55,7 @@ mod tests {
     use super::*;
 
     fn test_escape_case(input: &str, expected: &str) {
-        let input_os_str = OsStr::from_bytes(input.as_bytes());
-        let observed_os_str = escape(input_os_str);
-        let expected_os_str = OsStr::from_bytes(expected.as_bytes());
-        assert_eq!(observed_os_str, expected_os_str);
+        test_escape_from_bytes(input.as_bytes(), expected.as_bytes())
     }
 
     fn test_escape_from_bytes(input: &[u8], expected: &[u8]) {

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -32,10 +32,11 @@ pub fn escape(s: &OsStr) -> Cow<'_, OsStr> {
     let all_whitelisted = s.iter().copied().all(whitelisted);
 
     if !s.is_empty() && all_whitelisted {
-        return OsString::from_vec(s.to_vec()).into();
+        return Cow::Borrowed(s);
     }
 
     let mut escaped = Vec::with_capacity(s.len() + 2);
+    escaped.reserve(4);
     escaped.push(b'\'');
 
     for &b in s {
@@ -62,6 +63,13 @@ mod tests {
         let input_os_str = OsStr::from_bytes(input.as_bytes());
         let observed_os_str = escape(input_os_str);
         let expected_os_str = OsStr::from_bytes(expected.as_bytes());
+        assert_eq!(observed_os_str, expected_os_str);
+    }
+
+    fn test_escape_from_bytes(input: &[u8], expected: &[u8]) {
+        let input_os_str = OsStr::from_bytes(input);
+        let observed_os_str = escape(input_os_str);
+        let expected_os_str = OsStr::from_bytes(expected);
         assert_eq!(observed_os_str, expected_os_str);
     }
 
@@ -95,6 +103,11 @@ mod tests {
         test_escape_case(
             " ",
             r#"' '"#
+        );
+
+        test_escape_from_bytes(
+            &[0x66, 0x6f, 0x80, 0x6f],
+            &[b'\'', 0x66, 0x6f, 0x80, 0x6f, b'\'']
         );
     }
 }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -1,29 +1,28 @@
 //! Escape characters that may have special meaning in a shell, including spaces.
 //! This is a modified version of the [`shell-escape::unix`] module of [`shell-escape`] crate.
-//! 
+//!
 //! [`shell-escape`]: https://crates.io/crates/shell-escape
 //! [`shell-escape::unix`]: https://docs.rs/shell-escape/latest/src/shell_escape/lib.rs.html#101
 
 use std::{
-    borrow::Cow, 
+    borrow::Cow,
     ffi::{OsStr, OsString},
     os::unix::ffi::OsStrExt,
     os::unix::ffi::OsStringExt,
 };
-
 
 fn whitelisted(byte: u8) -> bool {
     matches!(byte, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'=' | b'/' | b',' | b'.' | b'+')
 }
 
 /// Escape characters that may have special meaning in a shell, including spaces.
-/// 
+///
 /// **Note**: This function is an adaptation of [`shell-escape::unix::escape`].
 /// This function exists only for type compatibility and the implementation is
 /// almost exactly the same as [`shell-escape::unix::escape`].
-/// 
+///
 /// [`shell-escape::unix::escape`]: https://docs.rs/shell-escape/latest/src/shell_escape/lib.rs.html#101
-/// 
+///
 pub(crate) fn escape(s: &OsStr) -> Cow<'_, OsStr> {
     let as_bytes = s.as_bytes();
     let all_whitelisted = as_bytes.iter().copied().all(whitelisted);
@@ -51,7 +50,6 @@ pub(crate) fn escape(s: &OsStr) -> Cow<'_, OsStr> {
     OsString::from_vec(escaped).into()
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -75,36 +73,21 @@ mod tests {
     fn test_escape() {
         test_escape_case(
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=/,.+",
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=/,.+"
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=/,.+",
         );
-        test_escape_case(
-            "--aaa=bbb-ccc",
-            "--aaa=bbb-ccc"
-        );
+        test_escape_case("--aaa=bbb-ccc", "--aaa=bbb-ccc");
         test_escape_case(
             "linker=gcc -L/foo -Wl,bar",
-            r#"'linker=gcc -L/foo -Wl,bar'"#
+            r#"'linker=gcc -L/foo -Wl,bar'"#,
         );
-        test_escape_case(
-            r#"--features="default""#,
-            r#"'--features="default"'"#
-        );
-        test_escape_case(
-            r#"'!\$`\\\n "#,
-            r#"''\'''\!'\$`\\\n '"#
-        );
-        test_escape_case(
-            "",
-            r#"''"#
-        );
-        test_escape_case(
-            " ",
-            r#"' '"#
-        );
+        test_escape_case(r#"--features="default""#, r#"'--features="default"'"#);
+        test_escape_case(r#"'!\$`\\\n "#, r#"''\'''\!'\$`\\\n '"#);
+        test_escape_case("", r#"''"#);
+        test_escape_case(" ", r#"' '"#);
 
         test_escape_from_bytes(
             &[0x66, 0x6f, 0x80, 0x6f],
-            &[b'\'', 0x66, 0x6f, 0x80, 0x6f, b'\'']
+            &[b'\'', 0x66, 0x6f, 0x80, 0x6f, b'\''],
         );
     }
 }

--- a/src/escape.rs
+++ b/src/escape.rs
@@ -38,6 +38,7 @@ pub(crate) fn escape(s: &OsStr) -> Cow<'_, OsStr> {
     for &b in as_bytes {
         match b {
             b'\'' | b'!' => {
+                escaped.reserve(4);
                 escaped.push(b'\'');
                 escaped.push(b'\\');
                 escaped.push(b);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,8 +167,7 @@ mod builder;
 pub use builder::{KnownHosts, SessionBuilder};
 
 mod command;
-pub use command::Command;
-pub use command::OverSsh;
+pub use command::{Command, OverSsh};
 
 mod child;
 pub use child::RemoteChild;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,7 @@ pub use builder::{KnownHosts, SessionBuilder};
 
 mod command;
 pub use command::Command;
+pub use command::OverSsh;
 
 mod child;
 pub use child::RemoteChild;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,8 +169,7 @@ pub use builder::{KnownHosts, SessionBuilder};
 mod command;
 pub use command::{Command, OverSsh};
 
-mod escape;
-pub use escape::escape;
+pub(crate) mod escape;
 
 mod child;
 pub use child::RemoteChild;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,9 @@ pub use builder::{KnownHosts, SessionBuilder};
 mod command;
 pub use command::{Command, OverSsh};
 
+mod escape;
+pub use escape::escape;
+
 mod child;
 pub use child::RemoteChild;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub use builder::{KnownHosts, SessionBuilder};
 mod command;
 pub use command::{Command, OverSsh};
 
-pub(crate) mod escape;
+mod escape;
 
 mod child;
 pub use child::RemoteChild;

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -323,11 +323,11 @@ async fn over_session_ok() {
 async fn over_session_ok_require_escaping_arguments() {
     for session in connects().await {
         let mut command = std::process::Command::new("echo")
-            .arg("\"\'\'foo\'\'\"")
+            .arg("\"\'\' foo \'\'\"")
             .over_ssh(&session).expect("No env vars or current working dir is set.");
 
         let child = command.output().await.unwrap();
-        assert_eq!(child.stdout, b"\"\'\'foo\'\'\"\n");
+        assert_eq!(child.stdout, b"\"\'\' foo \'\'\"\n");
 
         let child = session
             .command("echo")

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -298,7 +298,8 @@ async fn over_session_ok() {
     for session in connects().await {
         let mut command = std::process::Command::new("echo")
             .arg("foo")
-            .over_ssh(&session).expect("No env vars or current working dir is set.");
+            .over_ssh(&session)
+            .expect("No env vars or current working dir is set.");
 
         let child = command.output().await.unwrap();
         assert_eq!(child.stdout, b"foo\n");
@@ -317,14 +318,14 @@ async fn over_session_ok() {
     }
 }
 
-
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]
 async fn over_session_ok_require_escaping_arguments() {
     for session in connects().await {
         let mut command = std::process::Command::new("echo")
             .arg("\"\'\' foo \'\'\"")
-            .over_ssh(&session).expect("No env vars or current working dir is set.");
+            .over_ssh(&session)
+            .expect("No env vars or current working dir is set.");
 
         let child = command.output().await.unwrap();
         assert_eq!(child.stdout, b"\"\'\' foo \'\'\"\n");
@@ -352,7 +353,10 @@ async fn over_session_err_because_env_var() {
             .arg("MY_ENV_VAR")
             .env("MY_ENV_VAR", "foo")
             .over_ssh(&session);
-        assert!(matches!(command_with_env, Err(openssh::Error::CommandHasEnv)));
+        assert!(matches!(
+            command_with_env,
+            Err(openssh::Error::CommandHasEnv)
+        ));
     }
 }
 
@@ -365,7 +369,10 @@ async fn over_session_err_because_cwd() {
             .arg("foo")
             .current_dir("/tmp")
             .over_ssh(&session);
-        assert!(matches!(command_with_current_dir, Err(openssh::Error::CommandHasCwd)));
+        assert!(matches!(
+            command_with_current_dir,
+            Err(openssh::Error::CommandHasCwd)
+        ));
     }
 }
 

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -292,13 +292,11 @@ async fn stdout() {
     }
 }
 
-
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]
 async fn over_session() {
     for session in connects().await {
-        let mut command = 
-            std::process::Command::new("echo")
+        let mut command = std::process::Command::new("echo")
             .arg("foo")
             .over_session(&session);
 
@@ -318,7 +316,6 @@ async fn over_session() {
         session.close().await.unwrap();
     }
 }
-
 
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -6,7 +6,7 @@ use std::{
     net::IpAddr,
     path::PathBuf,
     process,
-    time::Duration, ffi::OsStr, os::unix::prelude::OsStrExt,
+    time::Duration,
 };
 use tempfile::tempdir;
 use tokio::{
@@ -295,7 +295,7 @@ async fn stdout() {
 
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]
-async fn with_session() {
+async fn over_session() {
     for session in connects().await {
         let mut command = 
             std::process::Command::new("echo")

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -300,8 +300,7 @@ async fn with_session() {
         let mut command = 
             std::process::Command::new("echo")
             .arg("foo")
-            .with_session(&session)
-            .expect("Expected valid utf-8 command.");
+            .over_session(&session);
 
         let child = command.output().await.unwrap();
         assert_eq!(child.stdout, b"foo\n");
@@ -315,40 +314,6 @@ async fn with_session() {
             .await
             .unwrap();
         assert!(child.stdout.is_empty());
-
-        session.close().await.unwrap();
-    }
-}
-
-
-#[tokio::test]
-#[cfg_attr(not(ci), ignore)]
-async fn with_session_err() {
-    
-    for session in connects().await {
-        let bad_string = OsStr::from_bytes(b"foo\xFF");
-        let command = 
-            std::process::Command::new("echo")
-            .arg(bad_string)
-            .with_session(&session);
-        
-        let expected_error = openssh::Error::InvalidUtf8String(bad_string.to_owned());
-        assert!(command.is_err());
-        let err = command.unwrap_err();
-        assert_eq!(err.to_string(), expected_error.to_string());
-
-        // let child = command.output().await.unwrap();
-        // assert_eq!(child.stdout, b"foo\n");
-
-        // let child = session
-        //     .command("echo")
-        //     .arg("foo")
-        //     .raw_arg(">")
-        //     .arg("/dev/stderr")
-        //     .output()
-        //     .await
-        //     .unwrap();
-        // assert!(child.stdout.is_empty());
 
         session.close().await.unwrap();
     }


### PR DESCRIPTION
The `std::process::Command` and the `openssh::Command` APIs are fairly similar, so I wonder if it is reasonable to allow an arbitrary `std::process::Command` to be run over ssh.

#### Example

```rust
use std::process;
use openssh::{OverSsh, Session, KnownHosts};

#[tokio::main]
pub async fn main() {
    let session = Session::connect_mux("me@ssh.example.com", KnownHosts::Strict).await.unwrap();

    let ls = process::Command::new("ls")
        .arg("-l")
        .arg("-h")
        .over_ssh(&session)
        .expect("no env vars or current_dir are specified")
        .output()
        .await
        .unwrap();

    println!("{}", String::from_utf8_lossy(&ls.stdout));
}


```