### PR TITLE
Speedup CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,19 +15,30 @@ on:
       - 'start_sshd.sh'
       - 'stop_sshd.sh'
 name: coverage
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  # makes all the ignored tests not ignored
+  RUSTFLAGS: --cfg=ci
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: llvm-tools-preview
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile minimal --component llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Create Cargo.lock for caching
+        run: cargo update
+      - uses: Swatinem/rust-cache@v2
+
       - run: |
           # Wait for startup of openssh-server
           timeout 15 ./wait_for_sshd_start_up.sh
@@ -44,8 +55,6 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --lcov --output-path lcov.info
         env:
-          # makes all the ignored tests not ignored
-          RUSTFLAGS: --cfg=ci
           # we cannot use 127.0.0.1 (the default here)
           # since we are running from a different container
           TEST_HOST: ssh://test-user@localhost:2222

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -15,18 +15,29 @@ on:
       - 'start_sshd.sh'
       - 'stop_sshd.sh'
 name: cargo hack
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  # makes all the ignored tests not ignored
+  RUSTFLAGS: --cfg=ci
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile minimal
       - uses: actions/checkout@v3
+
       - uses: taiki-e/install-action@cargo-hack
+      - name: Create Cargo.lock for caching
+        run: cargo update
+      - uses: Swatinem/rust-cache@v2
+
       - name: cargo hack
-        uses: actions-rs/cargo@v1
-        with:
-          command: hack
-          args: --feature-powerset check --all-targets
+        run: |
+          cargo hack --feature-powerset check --all-targets

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -15,19 +15,31 @@ on:
       - 'start_sshd.sh'
       - 'stop_sshd.sh'
 name: With dependencies at minimal versions
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  # makes all the ignored tests not ignored
+  RUSTFLAGS: --cfg=ci
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile minimal
+          rustup toolchain install nightly --no-self-update --profile minimal
       - uses: actions/checkout@v3
+
+      - name: cargo update -Zminimal-versions
+        run: cargo +nightly -Zminimal-versions update
+      - uses: Swatinem/rust-cache@v2
+      - name: Compile tests
+        run: cargo test --all-features --workspace --no-run
+
       - run: |
           # Wait for startup of openssh-server
           timeout 15 ./wait_for_sshd_start_up.sh
@@ -41,20 +53,10 @@ jobs:
           echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV
           cat .test-key | ssh-add -
         name: Set up ssh-agent
-      - name: cargo update -Zminimal-versions
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-          toolchain: nightly
-          args: -Zminimal-versions
       - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: |
+          cargo test --all-features
         env:
-          # makes all the ignored tests not ignored
-          RUSTFLAGS: --cfg=ci
           XDG_RUNTIME_DIR: /tmp
     services:
       openssh:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -15,17 +15,27 @@ on:
       - 'start_sshd.sh'
       - 'stop_sshd.sh'
 name: Minimum Supported Rust Version
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.63.0
-          override: true
+      - name: Install toolchain
+        run: |
+          rustup toolchain install 1.63 --no-self-update --profile minimal
+          rustup toolchain install nightly --no-self-update --profile minimal
+          rustup override set 1.63
+          rustup default 1.63
       - uses: actions/checkout@v3
+
+      - name: cargo update -Zminimal-versions
+        run: cargo +nightly -Zminimal-versions update
+      - uses: Swatinem/rust-cache@v2
+
       - name: cargo +1.63.0 check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: |
+          cargo +1.63 check

--- a/.github/workflows/os-check.yml
+++ b/.github/workflows/os-check.yml
@@ -15,6 +15,11 @@ on:
       - 'start_sshd.sh'
       - 'stop_sshd.sh'
 name: os check
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   os-check:
     runs-on: ${{ matrix.os }}
@@ -24,13 +29,14 @@ jobs:
       matrix:
         os: [macos-latest]
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile minimal
       - uses: actions/checkout@v3
+
+      - name: Create Cargo.lock for caching
+        run: cargo update
+      - uses: Swatinem/rust-cache@v2
+
       - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --all-targets
+        run: cargo test --all-features --all-targets

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,6 +15,11 @@ on:
       - 'start_sshd.sh'
       - 'stop_sshd.sh'
 name: lint
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   style:
     runs-on: ubuntu-latest
@@ -24,18 +29,18 @@ jobs:
       matrix:
         toolchain: [stable, beta]
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          components: rustfmt, clippy
-          override: true
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${{ matrix.toolchain }} --no-self-update --profile minimal --component rustfmt,clippy
+          rustup override set ${{ matrix.toolchain }}
+          rustup default ${{ matrix.toolchain }}
       - uses: actions/checkout@v3
-      - name: cargo fmt --check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --check
+
+      - name: Create Cargo.lock for caching
+        run: cargo update
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo fmt --check
       - name: cargo clippy
         uses: actions-rs/clippy-check@v1
         if: always()
@@ -43,17 +48,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   doc:
     runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: --cfg docsrs
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
+      - name: Install toolchain
+        run: |
+          rustup toolchain install nightly --no-self-update --profile minimal
+          rustup override set nightly
+          rustup default nightly
       - uses: actions/checkout@v3
-      - name: cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: nightly
-          command: doc
-          args: --no-deps --all-features
-        env:
-          RUSTDOCFLAGS: --cfg docsrs
+
+      - name: Create Cargo.lock for caching
+        run: cargo update
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo +nightly doc --no-deps --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,15 @@ on:
       - 'start_sshd.sh'
       - 'stop_sshd.sh'
 name: cargo test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  # makes all the ignored tests not ignored
+  RUSTFLAGS: --cfg=ci
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -23,12 +32,19 @@ jobs:
       matrix:
         toolchain: [stable, beta, nightly]
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${{ matrix.toolchain }} --no-self-update --profile minimal
+          rustup override set ${{ matrix.toolchain }}
+          rustup default ${{ matrix.toolchain }}
       - uses: actions/checkout@v3
+
+      - name: Create Cargo.lock for caching
+        run: cargo update
+      - uses: Swatinem/rust-cache@v2
+      - name: Compile tests
+        run: cargo test --all-features --workspace --no-run
+
       - run: |
           # Wait for startup of openssh-server
           timeout 15 ./wait_for_sshd_start_up.sh
@@ -42,14 +58,8 @@ jobs:
           echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> $GITHUB_ENV
           cat .test-key | ssh-add -
         name: Set up ssh-agent
-      - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+      - run: cargo test --all-features
         env:
-          # makes all the ignored tests not ignored
-          RUSTFLAGS: --cfg=ci
           XDG_RUNTIME_DIR: /tmp
       - run: docker logs $(docker ps | grep openssh-server | awk '{print $1}')
         name: ssh container log


### PR DESCRIPTION
 - Remove deprecated `actions-rs/toolchain@v1`
 - Use `concurrency` to cancel outdated CI runs
 - Use `Swatinem/rust-cache@v2` for caching
 - Compile tests before waiting for container startup