### PR TITLE
Attempt at providing an owned version of command

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -5,7 +5,20 @@ use crate::*;
 ///
 /// ## Added
 ///  - Add new fn `SessionBuilder::ssh_auth_sock`
+///  - Add new fns [`Session::arc_command`], [`Session::arc_raw_command`],
+///    [`Session::to_command`], and [`Session::to_raw_command`] to support
+///    session-owning commands
+///  - Add generic [`crate::OwningCommand`], to support session-owning
+///    commands.
+///  - Add [`crate::child::Child`] as a generic version of [`RemoteChild`]
+///    to support session-owning commands
 /// ## Changed
+///  - Change [`RemoteChild`] to be an alias to [`crate::child::Child`]
+///    owning a session references.
+///  - Change [`Command`] to be an alias to [`OwningCommand`] owning a
+///    session reference.
+///  - Change [`OverSsh::over_ssh`] to be generic and support owned
+///    sessions.
 /// ## Removed
 #[doc(hidden)]
 pub mod unreleased {}

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,12 +1,13 @@
 use crate::escape::escape;
 
+use super::child::Child;
 use super::stdio::TryFromChildIo;
-use super::RemoteChild;
 use super::Stdio;
 use super::{Error, Session};
 
 use std::borrow::Cow;
 use std::ffi::OsStr;
+use std::ops::Deref;
 use std::process;
 
 #[derive(Debug)]
@@ -112,17 +113,17 @@ pub trait OverSsh {
     /// }
     ///
     /// ```
-    fn over_ssh<'session>(
+    fn over_ssh<S: Deref<Target = Session> + Clone>(
         &self,
-        session: &'session Session,
-    ) -> Result<crate::Command<'session>, crate::Error>;
+        session: S,
+    ) -> Result<OwningCommand<S>, crate::Error>;
 }
 
 impl OverSsh for std::process::Command {
-    fn over_ssh<'session>(
+    fn over_ssh<S: Deref<Target = Session> + Clone>(
         &self,
-        session: &'session Session,
-    ) -> Result<Command<'session>, crate::Error> {
+        session: S,
+    ) -> Result<OwningCommand<S>, crate::Error> {
         // I'd really like `!self.get_envs().is_empty()` here, but that's
         // behind a `exact_size_is_empty` feature flag.
         if self.get_envs().len() > 0 {
@@ -134,7 +135,7 @@ impl OverSsh for std::process::Command {
         }
 
         let program_escaped: Cow<'_, OsStr> = escape(self.get_program());
-        let mut command = session.raw_command(program_escaped);
+        let mut command = Session::to_raw_command(session, program_escaped);
 
         let args = self.get_args().map(escape);
         command.raw_args(args);
@@ -143,10 +144,10 @@ impl OverSsh for std::process::Command {
 }
 
 impl OverSsh for tokio::process::Command {
-    fn over_ssh<'session>(
+    fn over_ssh<S: Deref<Target = Session> + Clone>(
         &self,
-        session: &'session Session,
-    ) -> Result<Command<'session>, crate::Error> {
+        session: S,
+    ) -> Result<OwningCommand<S>, crate::Error> {
         self.as_std().over_ssh(session)
     }
 }
@@ -155,10 +156,10 @@ impl<S> OverSsh for &S
 where
     S: OverSsh,
 {
-    fn over_ssh<'session>(
+    fn over_ssh<U: Deref<Target = Session> + Clone>(
         &self,
-        session: &'session Session,
-    ) -> Result<Command<'session>, crate::Error> {
+        session: U,
+    ) -> Result<OwningCommand<U>, crate::Error> {
         <S as OverSsh>::over_ssh(self, session)
     }
 }
@@ -167,10 +168,10 @@ impl<S> OverSsh for &mut S
 where
     S: OverSsh,
 {
-    fn over_ssh<'session>(
+    fn over_ssh<U: Deref<Target = Session> + Clone>(
         &self,
-        session: &'session Session,
-    ) -> Result<Command<'session>, crate::Error> {
+        session: U,
+    ) -> Result<OwningCommand<U>, crate::Error> {
         <S as OverSsh>::over_ssh(self, session)
     }
 }
@@ -178,18 +179,19 @@ where
 /// A remote process builder, providing fine-grained control over how a new remote process should
 /// be spawned.
 ///
-/// A default configuration can be generated using [`Session::command(program)`](Session::command),
-/// where `program` gives a path to the program to be executed. Additional builder methods allow
-/// the configuration to be changed (for example, by adding arguments) prior to spawning.  The
-/// interface is almost identical to that of [`std::process::Command`].
+/// A default configuration can be generated using [`Session::command(program)`](Session::command)
+/// or [`Session::arc_command(program)`](Session::arc_command), where `program` gives a path to
+/// the program to be executed. Additional builder methods allow the configuration to be changed
+/// (for example, by adding arguments) prior to spawning. The interface is almost identical to
+/// that of [`std::process::Command`].
 ///
-/// `Command` can be reused to spawn multiple remote processes. The builder methods change the
-/// command without needing to immediately spawn the process. Similarly, you can call builder
+/// `OwningCommand` can be reused to spawn multiple remote processes. The builder methods change
+/// the command without needing to immediately spawn the process. Similarly, you can call builder
 /// methods after spawning a process and then spawn a new process with the modified settings.
 ///
 /// # Environment variables and current working directory.
 ///
-/// You'll notice that unlike its `std` counterpart, `Command` does not have any methods for
+/// You'll notice that unlike its `std` counterpart, `OwningCommand` does not have any methods for
 /// setting environment variables or the current working directory for the remote command. This is
 /// because the SSH protocol does not support this (at least not in its standard configuration).
 /// For more details on this, see the `ENVIRONMENT` section of [`ssh(1)`]. To work around this,
@@ -207,8 +209,8 @@ where
 ///   [`ssh(1)`]: https://linux.die.net/man/1/ssh
 ///   [`env(1)`]: https://linux.die.net/man/1/env
 #[derive(Debug)]
-pub struct Command<'s> {
-    session: &'s Session,
+pub struct OwningCommand<S> {
+    session: S,
     imp: CommandImp,
 
     stdin_set: bool,
@@ -216,8 +218,8 @@ pub struct Command<'s> {
     stderr_set: bool,
 }
 
-impl<'s> Command<'s> {
-    pub(crate) fn new(session: &'s super::Session, imp: CommandImp) -> Self {
+impl<S> OwningCommand<S> {
+    pub(crate) fn new(session: S, imp: CommandImp) -> Self {
         Self {
             session,
             imp,
@@ -231,7 +233,8 @@ impl<'s> Command<'s> {
     /// Adds an argument to pass to the remote program.
     ///
     /// Before it is passed to the remote host, `arg` is escaped so that special characters aren't
-    /// evaluated by the remote shell. If you do not want this behavior, use [`raw_arg`](Command::raw_arg).
+    /// evaluated by the remote shell. If you do not want this behavior, use
+    /// [`raw_arg`](Self::raw_arg).
     ///
     /// Only one argument can be passed per use. So instead of:
     ///
@@ -250,20 +253,20 @@ impl<'s> Command<'s> {
     /// # ; }
     /// ```
     ///
-    /// To pass multiple arguments see [`args`](Command::args).
-    pub fn arg<S: AsRef<str>>(&mut self, arg: S) -> &mut Self {
+    /// To pass multiple arguments see [`args`](Self::args).
+    pub fn arg<A: AsRef<str>>(&mut self, arg: A) -> &mut Self {
         self.raw_arg(&*shell_escape::unix::escape(Cow::Borrowed(arg.as_ref())))
     }
 
     /// Adds an argument to pass to the remote program.
     ///
-    /// Unlike [`arg`](Command::arg), this method does not shell-escape `arg`. The argument is passed as written
+    /// Unlike [`arg`](Self::arg), this method does not shell-escape `arg`. The argument is passed as written
     /// to `ssh`, which will pass it again as an argument to the remote shell. Since the remote
     /// shell may do argument parsing, characters such as spaces and `*` may be interpreted by the
     /// remote shell.
     ///
-    /// To pass multiple unescaped arguments see [`raw_args`](Command::raw_args).
-    pub fn raw_arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+    /// To pass multiple unescaped arguments see [`raw_args`](Self::raw_args).
+    pub fn raw_arg<A: AsRef<OsStr>>(&mut self, arg: A) -> &mut Self {
         delegate!(&mut self.imp, imp, {
             imp.raw_arg(arg.as_ref());
         });
@@ -274,13 +277,13 @@ impl<'s> Command<'s> {
     ///
     /// Before they are passed to the remote host, each argument in `args` is escaped so that
     /// special characters aren't evaluated by the remote shell. If you do not want this behavior,
-    /// use [`raw_args`](Command::raw_args).
+    /// use [`raw_args`](Self::raw_args).
     ///
-    /// To pass a single argument see [`arg`](Command::arg).
-    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    /// To pass a single argument see [`arg`](Self::arg).
+    pub fn args<I, A>(&mut self, args: I) -> &mut Self
     where
-        I: IntoIterator<Item = S>,
-        S: AsRef<str>,
+        I: IntoIterator<Item = A>,
+        A: AsRef<str>,
     {
         for arg in args {
             self.arg(arg);
@@ -290,16 +293,16 @@ impl<'s> Command<'s> {
 
     /// Adds multiple arguments to pass to the remote program.
     ///
-    /// Unlike [`args`](Command::args), this method does not shell-escape `args`. The arguments are passed as
+    /// Unlike [`args`](Self::args), this method does not shell-escape `args`. The arguments are passed as
     /// written to `ssh`, which will pass them again as arguments to the remote shell. However,
     /// since the remote shell may do argument parsing, characters such as spaces and `*` may be
     /// interpreted by the remote shell.
     ///
-    /// To pass a single argument see [`raw_arg`](Command::raw_arg).
-    pub fn raw_args<I, S>(&mut self, args: I) -> &mut Self
+    /// To pass a single argument see [`raw_arg`](Self::raw_arg).
+    pub fn raw_args<I, A>(&mut self, args: I) -> &mut Self
     where
-        I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
+        I: IntoIterator<Item = A>,
+        A: AsRef<OsStr>,
     {
         for arg in args {
             self.raw_arg(arg);
@@ -351,10 +354,12 @@ impl<'s> Command<'s> {
         self.stderr_set = true;
         self
     }
+}
 
-    async fn spawn_impl(&mut self) -> Result<RemoteChild<'s>, Error> {
-        Ok(RemoteChild::new(
-            self.session,
+impl<S: Clone> OwningCommand<S> {
+    async fn spawn_impl(&mut self) -> Result<Child<S>, Error> {
+        Ok(Child::new(
+            self.session.clone(),
             delegate!(&mut self.imp, imp, {
                 let (imp, stdin, stdout, stderr) = imp.spawn().await?;
                 (
@@ -371,7 +376,7 @@ impl<'s> Command<'s> {
     /// instead.
     ///
     /// By default, stdin, stdout and stderr are inherited.
-    pub async fn spawn(&mut self) -> Result<RemoteChild<'s>, Error> {
+    pub async fn spawn(&mut self) -> Result<Child<S>, Error> {
         if !self.stdin_set {
             self.stdin(Stdio::inherit());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,15 +18,17 @@
 //! Note that the maximum number of multiplexed remote commands is 10 by default. This value can be
 //! increased by changing the `MaxSessions` setting in [`sshd_config`].
 //!
-//! Much like with [`std::process::Command`], you have multiple options when it comes to launching
-//! a remote command. You can [spawn](Command::spawn) the remote command, which just gives you a
-//! handle to the running process, you can run the command and wait for its
-//! [output](Command::output), or you can run it and just extract its [exit
-//! status](Command::status). Unlike its `std` counterpart though, these methods on [`Command`] can
-//! fail even if the remote command executed successfully, since there is a fallible network
-//! separating you from it.
+//! Much like with [`std::process::Command`], you have multiple
+//! options when it comes to launching a remote command. You can
+//! [spawn](Command::spawn) the remote command, which just gives you a
+//! handle to the running process, you can run the command and wait
+//! for its [output](Command::output), or you can run it and just
+//! extract its [exit status](Command::status). Unlike its `std`
+//! counterpart though, these methods on [`OwningCommand`] can fail
+//! even if the remote command executed successfully, since there is a
+//! fallible network separating you from it.
 //!
-//! Also unlike its `std` counterpart, [`spawn`](Command::spawn) gives you a [`RemoteChild`] rather
+//! Also unlike its `std` counterpart, [`spawn`](OwningCommand::spawn) gives you a [`Child`] rather
 //! than a [`std::process::Child`]. Behind the scenes, a remote child is really just a process
 //! handle to the _local_ `ssh` instance corresponding to the spawned remote command. The behavior
 //! of the methods of [`RemoteChild`] therefore match the behavior of `ssh`, rather than that of
@@ -167,12 +169,16 @@ mod builder;
 pub use builder::{KnownHosts, SessionBuilder};
 
 mod command;
-pub use command::{Command, OverSsh};
+pub use command::{OverSsh, OwningCommand};
+/// Convenience [`OwningCommand`] alias when working with a session reference.
+pub type Command<'s> = OwningCommand<&'s Session>;
 
 mod escape;
 
 mod child;
-pub use child::RemoteChild;
+pub use child::Child;
+/// Convenience [`Child`] alias when working with a session reference.
+pub type RemoteChild<'a> = Child<&'a Session>;
 
 mod error;
 pub use error::Error;

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -1057,3 +1057,83 @@ async fn test_read_large_file_bug() {
         assert_eq!(stdout.len(), bs * count);
     }
 }
+
+#[tokio::test]
+#[cfg_attr(not(ci), ignore)]
+async fn test_session_arc_command() {
+    for session in connects().await {
+        let session = std::sync::Arc::new(session);
+        let mut child = session
+            .clone()
+            .arc_command("cat")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .await
+            .unwrap();
+
+        drop(session);
+
+        // write something to standard in and send EOF
+        let mut stdin = child.stdin().take().unwrap();
+        stdin.write_all(b"hello world").await.unwrap();
+        drop(stdin);
+
+        // cat should print it back on stdout
+        let mut stdout = child.stdout().take().unwrap();
+        let mut out = String::new();
+        stdout.read_to_string(&mut out).await.unwrap();
+        assert_eq!(out, "hello world");
+        drop(stdout);
+
+        // cat should now have terminated
+        let status = child.wait().await.unwrap();
+
+        // ... successfully
+        assert!(status.success());
+    }
+}
+
+#[tokio::test]
+#[cfg_attr(not(ci), ignore)]
+async fn test_session_to_command() {
+    for session in connects().await {
+        test_to_command(&session).await;
+    }
+    for session in connects().await {
+        test_to_command(std::rc::Rc::new(session)).await;
+    }
+    for session in connects().await {
+        test_to_command(std::sync::Arc::new(session)).await;
+    }
+
+    async fn test_to_command<S>(session: S)
+    where
+        S: Clone + std::ops::Deref<Target = Session>,
+    {
+        let mut child = Session::to_command(session, "cat")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .await
+            .unwrap();
+
+        // write something to standard in and send EOF
+        let mut stdin = child.stdin().take().unwrap();
+        stdin.write_all(b"hello world").await.unwrap();
+        drop(stdin);
+
+        // cat should print it back on stdout
+        let mut stdout = child.stdout().take().unwrap();
+        let mut out = String::new();
+        stdout.read_to_string(&mut out).await.unwrap();
+        assert_eq!(out, "hello world");
+        drop(stdout);
+
+        // cat should now have terminated
+        let status = child.wait().await.unwrap();
+
+        // ... successfully
+        assert!(status.success());
+    }
+}


### PR DESCRIPTION
Pushing this to run the tests as getting things to work locally on a mac seems like a bit of a bear.

- Could not get the lifetimes right to not break `RemoteChild::session` (the lifetime becomes bound to the child's rather than the original session's), so move it into its own impl block, and added an extremely debatable `Child::into_session`, since it means not being able to call `wait`, or `wait_with_output`, or `disconnect`, so probably not useful (but a slightly separate variant of `Child::session` seems awful).
- Initially wanted to have a version directly owning a `Session`, but that turns out impossible as the `Command` builder works off of mutable references, so not possible to consume the builder in order to get the session out, short of creating either separate `impl` blocks for `Command<&Session>`, `Command<Arc<Session>>` and `Command<Session>`, or separate consuming spawns, neither sounding great.
- Naming is dubious, especially `shared_command`, but I don't recall ever seeing a method around shared refs so I went simple. I would have impl'd `Arc<Session>::into_command` but that's not legal...

  Maybe a free function would be better?

Hopefully will eventually fix #117
