### PR TITLE
Use rfind to locate the @ in connection string

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -319,7 +319,7 @@ impl SessionBuilder {
         let mut port = None;
         if destination.starts_with("ssh://") {
             destination = &destination[6..];
-            if let Some(at) = destination.find('@') {
+            if let Some(at) = destination.rfind('@') {
                 // specified a username -- extract it:
                 user = Some(&destination[..at]);
                 destination = &destination[(at + 1)..];


### PR DESCRIPTION
[Our counterparty](https://transparency.entsoe.eu/content/static_content/Static%20content/knowledge%20base/SFTP%20guide.html) uses email addresses as usernames. The connection string looks something like

```
ssh://john.doe@example.com:johnspassword@sftp-transparency.entsoe.eu
```

The `resolve` function looks for the `@` when parsing the URL using `find` function. That finds the first `@` which means the username is `john.doe` instead of `john.doe@example.com`. Using `rfind` instead resolves this issue. I'm not sure if this is valid according to [the URL standard](https://url.spec.whatwg.org). It should not break any existing existing functionality as the hostname [seems to not allow @ sign](https://stackoverflow.com/questions/1856785/characters-allowed-in-a-url).

Perhaps a better approach would be to rely on an external crate for this. The [url crate](https://docs.rs/url/latest/url/) comes to mind. 