### PR TITLE
Drop MPL licensed dependency dirs-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
 tokio-pipe = "0.2.8"
 
 once_cell = "1.8.0"
-dirs = "5.0.0"
 
 openssh-mux-client = { version = "0.17.0", optional = true }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,10 +8,31 @@ use std::process::Stdio;
 use std::str;
 use std::{fs, io};
 
-use dirs::state_dir;
 use once_cell::sync::OnceCell;
 use tempfile::{Builder, TempDir};
 use tokio::process;
+
+#[cfg(not(windows))]
+fn state_dir() -> Option<PathBuf> {
+    fn get_absolute_path(path: OsString) -> Option<PathBuf> {
+        let path = PathBuf::from(path);
+        path.is_absolute().then_some(path)
+    }
+
+    #[allow(deprecated)]
+    if let Some(xdg) = std::env::var_os("XDG_STATE_HOME") {
+        get_absolute_path(xdg)
+    } else if let Some(home) = std::env::home_dir() {
+        Some(get_absolute_path(home.into())?.join(".local/state"))
+    } else {
+        None
+    }
+}
+
+#[cfg(windows)]
+fn state_dir() -> Option<PathBuf> {
+    None
+}
 
 /// The returned `&'static Path` can be coreced to any lifetime.
 fn get_default_control_dir<'a>() -> Result<&'a Path, Error> {
@@ -157,10 +178,9 @@ impl SessionBuilder {
     /// Set the directory in which the temporary directory containing the control socket will
     /// be created.
     ///
-    /// If not set, openssh will try to use [`dirs::state_dir`] and fallback to
+    /// If not set, openssh will try to use `$XDG_STATE_HOME`, `$HOME/.local/state` on unix, and fallback to
     /// `./` (the current directory) if it failed.
     ///
-    /// [`dirs::state_dir`]: https://docs.rs/dirs/latest/dirs/fn.state_dir.html
     #[cfg(not(windows))]
     #[cfg_attr(docsrs, doc(cfg(not(windows))))]
     pub fn control_directory(&mut self, p: impl AsRef<Path>) -> &mut Self {

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -2,6 +2,8 @@
 use crate::*;
 
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
+/// ## Changed
+/// - Removed dependency on MPL licensed dirs-sys in favor of local implementation
 #[doc(hidden)]
 pub mod unreleased {}
 


### PR DESCRIPTION
Dependabot updated `dirs` crate to version 5.0.0 here: https://github.com/openssh-rust/openssh/pull/114. Between versions 4.0 and 5.0 dirs crate included a small dependency with MPL license, there's several tickets to dirs crate about this issue closed as WONTFIX, you can find some relevant links here: https://github.com/harryfei/which-rs/pull/78

One possible solution is to pin `dirs` to some older version, but functionality used by `openssh` is simple enough to implement from scratch