### PR TITLE
Make `-o ControlPersist` configurable

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -507,6 +507,9 @@ pub enum ControlPersist {
     ClosedAfterInitialConnection,
     /// If the ssh control server has been idle for specified duration, it will
     /// exit.
+    ///
+    /// If a duration shorter than 1 second is passed, it will be rounded up
+    /// to 1 second.
     IdleFor(std::time::Duration),
 }
 
@@ -515,7 +518,9 @@ impl ControlPersist {
         match self {
             ControlPersist::Forever => Cow::Borrowed("ControlPersist=yes"),
             ControlPersist::ClosedAfterInitialConnection => Cow::Borrowed("ControlPersist=no"),
-            ControlPersist::IdleFor(d) => Cow::Owned(format!("ControlPersist={}s", d.as_secs())),
+            ControlPersist::IdleFor(d) => {
+                Cow::Owned(format!("ControlPersist={}s", std::cmp::max(1, d.as_secs())))
+            }
         }
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -85,6 +85,7 @@ pub struct SessionBuilder {
     server_alive_interval: Option<u64>,
     known_hosts_check: KnownHosts,
     control_dir: Option<PathBuf>,
+    control_persist: Option<String>,
     clean_history_control_dir: bool,
     config_file: Option<PathBuf>,
     compression: Option<bool>,
@@ -103,6 +104,7 @@ impl Default for SessionBuilder {
             server_alive_interval: None,
             known_hosts_check: KnownHosts::Add,
             control_dir: None,
+            control_persist: None,
             clean_history_control_dir: false,
             config_file: None,
             compression: None,
@@ -199,6 +201,15 @@ impl SessionBuilder {
     #[cfg_attr(docsrs, doc(cfg(not(windows))))]
     pub fn clean_history_control_directory(&mut self, clean: bool) -> &mut Self {
         self.clean_history_control_dir = clean;
+        self
+    }
+
+    /// Set the ControlPersist option (`ssh -o ControlPersist=<value>`).
+    ///
+    /// If not set, openssh will use "ControlPersist=yes".
+    ///
+    pub fn control_persist(&mut self, value: String) -> &mut Self {
+        self.control_persist = Some(value);
         self
     }
 
@@ -405,7 +416,10 @@ impl SessionBuilder {
             .arg("-f")
             .arg("-N")
             .arg("-o")
-            .arg("ControlPersist=yes")
+            .arg(format!(
+                "ControlPersist={}",
+                self.control_persist.as_deref().unwrap_or("yes")
+            ))
             .arg("-o")
             .arg("BatchMode=yes")
             .arg("-o")

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,6 +3,7 @@ use super::{Error, Session};
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::iter::IntoIterator;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str;
@@ -417,7 +418,7 @@ impl SessionBuilder {
             .arg("-f")
             .arg("-N")
             .arg("-o")
-            .arg(self.control_persist.as_option())
+            .arg(self.control_persist.as_option().deref())
             .arg("-o")
             .arg("BatchMode=yes")
             .arg("-o")
@@ -510,11 +511,11 @@ pub enum ControlPersist {
 }
 
 impl ControlPersist {
-    fn as_option(&self) -> String {
-        match *self {
-            ControlPersist::Forever => "ControlPersist=yes".to_string(),
-            ControlPersist::ClosedAfterInitialConnection => "ControlPersist=no".to_string(),
-            ControlPersist::IdleFor(d) => format!("ControlPersist={}s", d.as_secs()),
+    fn as_option(&self) -> Cow<'_, str> {
+        match self {
+            ControlPersist::Forever => Cow::Borrowed("ControlPersist=yes"),
+            ControlPersist::ClosedAfterInitialConnection => Cow::Borrowed("ControlPersist=no"),
+            ControlPersist::IdleFor(d) => Cow::Owned(format!("ControlPersist={}s", d.as_secs())),
         }
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -505,12 +505,9 @@ pub enum ControlPersist {
     Forever,
     /// Will be closed after the initial connection is closed
     ClosedAfterInitialConnection,
-    /// If the ssh control server has been idle for specified duration, it will
-    /// exit.
-    ///
-    /// If a duration shorter than 1 second is passed, it will be rounded up
-    /// to 1 second.
-    IdleFor(std::time::Duration),
+    /// If the ssh control server has been idle for specified duration
+    /// (in seconds), it will exit.
+    IdleFor(std::num::NonZeroUsize),
 }
 
 impl ControlPersist {
@@ -518,9 +515,7 @@ impl ControlPersist {
         match self {
             ControlPersist::Forever => Cow::Borrowed("ControlPersist=yes"),
             ControlPersist::ClosedAfterInitialConnection => Cow::Borrowed("ControlPersist=no"),
-            ControlPersist::IdleFor(d) => {
-                Cow::Owned(format!("ControlPersist={}s", std::cmp::max(1, d.as_secs())))
-            }
+            ControlPersist::IdleFor(d) => Cow::Owned(format!("ControlPersist={}s", d.get())),
         }
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -208,8 +208,8 @@ impl SessionBuilder {
     ///
     /// If not set, openssh will use "ControlPersist=yes".
     ///
-    pub fn control_persist(&mut self, value: String) -> &mut Self {
-        self.control_persist = Some(value);
+    pub fn control_persist(&mut self, value: &str) -> &mut Self {
+        self.control_persist = Some(value.to_string());
         self
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -208,8 +208,8 @@ impl SessionBuilder {
     ///
     /// If not set, openssh will use "ControlPersist=yes".
     ///
-    pub fn control_persist(&mut self, value: &str) -> &mut Self {
-        self.control_persist = Some(value.to_string());
+    pub fn control_persist(&mut self, value: String) -> &mut Self {
+        self.control_persist = Some(value);
         self
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -497,6 +497,7 @@ impl SessionBuilder {
 
 /// Specifies how long the controlling ssh process should stay alive.
 #[derive(Clone, Debug, Default)]
+#[non_exhaustive]
 pub enum ControlPersist {
     /// Will stay alive indefinitely.
     #[default]

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -2,6 +2,9 @@
 use crate::*;
 
 /// TODO: RENAME THIS INTO THE NEXT VERSION BEFORE RELEASE
+/// ## Changed
+/// - Added new fn [`Session::control_persist`] to set the `ControlPersist` option of
+///   the master ssh connection.
 #[doc(hidden)]
 pub mod unreleased {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ mod session;
 pub use session::Session;
 
 mod builder;
-pub use builder::{KnownHosts, SessionBuilder};
+pub use builder::{ControlPersist, KnownHosts, SessionBuilder};
 
 mod command;
 pub use command::{OverSsh, OwningCommand};


### PR DESCRIPTION
The crate uses `ControlPersist=yes` per default. In practice we see the control processes around forever, and they are not reused across relaunches of the binary. So instead it would be nice to set the ControlPersist option to a custom value, so they can expire automatically after e.g. 5 minutes.