### PR TITLE
Remove dep tokio-pipe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tempfile = "3.9.0"
 shell-escape = "0.1.5"
 thiserror = "1.0.30"
 
-tokio = { version = "1", features = [ "process", "io-util", "macros", "net" ] }
+tokio = { version = "1.26.0", features = [ "process", "io-util", "macros", "net" ] }
 
 once_cell = "1.8.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,7 @@ tempfile = "3.9.0"
 shell-escape = "0.1.5"
 thiserror = "1.0.30"
 
-tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
-tokio-pipe = "0.2.8"
+tokio = { version = "1", features = [ "process", "io-util", "macros", "net" ] }
 
 once_cell = "1.8.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tempfile = "3.9.0"
 shell-escape = "0.1.5"
 thiserror = "1.0.30"
 
-tokio = { version = "1.26.0", features = [ "process", "io-util", "macros", "net" ] }
+tokio = { version = "1.36.0", features = [ "process", "io-util", "macros", "net" ] }
 
 once_cell = "1.8.0"
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -69,7 +69,7 @@ pub trait OverSsh {
     /// ###  Examples
     ///
     /// 1. Consider the implementation of `OverSsh` for `std::process::Command`. Let's build a
-    /// `ls -l -a -h` command and execute it over an SSH session.
+    ///    `ls -l -a -h` command and execute it over an SSH session.
     ///
     /// ```no_run
     /// # #[tokio::main(flavor = "current_thread")]
@@ -93,7 +93,7 @@ pub trait OverSsh {
     ///
     /// ```
     /// 2. Building a command with environment variables or a current working directory set will
-    /// results in an error.
+    ///    results in an error.
     ///
     /// ```no_run
     /// # #[tokio::main(flavor = "current_thread")]

--- a/src/native_mux_impl/stdio.rs
+++ b/src/native_mux_impl/stdio.rs
@@ -96,11 +96,9 @@ impl Stdio {
                 let (read, write) = create_pipe()?;
                 Ok((read.try_into()?, Some(write)))
             }
-            StdioImpl::Fd(fd, owned) => {
+            StdioImpl::Fd(fd) => {
                 let raw_fd = fd.as_raw_fd();
-                if *owned {
-                    set_blocking(raw_fd)?;
-                }
+                set_blocking(raw_fd)?;
                 Ok((Fd::Borrowed(raw_fd), None))
             }
         }
@@ -117,11 +115,9 @@ impl Stdio {
                 let (read, write) = create_pipe()?;
                 Ok((write.try_into()?, Some(read)))
             }
-            StdioImpl::Fd(fd, owned) => {
+            StdioImpl::Fd(fd) => {
                 let raw_fd = fd.as_raw_fd();
-                if *owned {
-                    set_blocking(raw_fd)?;
-                }
+                set_blocking(raw_fd)?;
                 Ok((Fd::Borrowed(raw_fd), None))
             }
         }

--- a/src/native_mux_impl/stdio.rs
+++ b/src/native_mux_impl/stdio.rs
@@ -8,10 +8,13 @@ use std::{
 
 use libc::{c_int, fcntl, F_GETFL, F_SETFL, O_NONBLOCK};
 use once_cell::sync::OnceCell;
-use tokio_pipe::{pipe, PipeRead, PipeWrite};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::unix::pipe::{pipe, Receiver as PipeReader, Sender as PipeWriter},
+};
 
-fn create_pipe() -> Result<(PipeRead, PipeWrite), Error> {
-    pipe().map_err(Error::ChildIo)
+fn create_pipe() -> Result<(PipeReader, PipeWriter), Error> {
+    pipe().map_err(Error::ChildIo).map(|(w, r)| (r, w))
 }
 
 /// Open "/dev/null" with RW.
@@ -74,27 +77,25 @@ impl Fd {
     }
 }
 
-impl TryFrom<PipeRead> for Fd {
+impl TryFrom<PipeReader> for Fd {
     type Error = Error;
 
-    fn try_from(pipe_read: PipeRead) -> Result<Self, Error> {
-        // Safety:
-        //
-        // PipeRead::into_raw_fd returns a valid fd and transfers the
-        // ownership of it.
-        unsafe { Self::new_owned(pipe_read) }
+    fn try_from(pipe_reader: PipeReader) -> Result<Self, Error> {
+        pipe_reader
+            .into_blocking_fd()
+            .map_err(Error::ChildIo)
+            .map(Fd::Owned)
     }
 }
 
-impl TryFrom<PipeWrite> for Fd {
+impl TryFrom<PipeWriter> for Fd {
     type Error = Error;
 
-    fn try_from(pipe_write: PipeWrite) -> Result<Self, Error> {
-        // Safety:
-        //
-        // PipeWrite::into_raw_fd returns a valid fd and transfers the
-        // ownership of it.
-        unsafe { Self::new_owned(pipe_write) }
+    fn try_from(pipe_writer: PipeWriter) -> Result<Self, Error> {
+        pipe_writer
+            .into_blocking_fd()
+            .map_err(Error::ChildIo)
+            .map(Fd::Owned)
     }
 }
 
@@ -105,10 +106,6 @@ impl Stdio {
             StdioImpl::Null => Ok((Fd::Null, None)),
             StdioImpl::Pipe => {
                 let (read, write) = create_pipe()?;
-
-                // read end will be sent to ssh multiplex server
-                // and it expects blocking fd.
-                set_blocking(read.as_raw_fd())?;
                 Ok((read.try_into()?, Some(write)))
             }
             StdioImpl::Fd(fd, owned) => {
@@ -121,16 +118,15 @@ impl Stdio {
         }
     }
 
-    fn to_output(&self, get_inherit_rawfd: fn() -> RawFd) -> Result<(Fd, Option<PipeRead>), Error> {
+    fn to_output(
+        &self,
+        get_inherit_rawfd: fn() -> RawFd,
+    ) -> Result<(Fd, Option<PipeReader>), Error> {
         match &self.0 {
             StdioImpl::Inherit => Ok((Fd::Borrowed(get_inherit_rawfd()), None)),
             StdioImpl::Null => Ok((Fd::Null, None)),
             StdioImpl::Pipe => {
                 let (read, write) = create_pipe()?;
-
-                // write end will be sent to ssh multiplex server
-                // and it expects blocking fd.
-                set_blocking(write.as_raw_fd())?;
                 Ok((write.try_into()?, Some(read)))
             }
             StdioImpl::Fd(fd, owned) => {
@@ -143,15 +139,15 @@ impl Stdio {
         }
     }
 
-    pub(crate) fn to_stdout(&self) -> Result<(Fd, Option<PipeRead>), Error> {
+    pub(crate) fn to_stdout(&self) -> Result<(Fd, Option<PipeReader>), Error> {
         self.to_output(|| io::stdout().as_raw_fd())
     }
 
-    pub(crate) fn to_stderr(&self) -> Result<(Fd, Option<PipeRead>), Error> {
+    pub(crate) fn to_stderr(&self) -> Result<(Fd, Option<PipeReader>), Error> {
         self.to_output(|| io::stderr().as_raw_fd())
     }
 }
 
-pub(crate) type ChildStdin = PipeWrite;
-pub(crate) type ChildStdout = PipeRead;
-pub(crate) type ChildStderr = PipeRead;
+pub(crate) type ChildStdin = PipeWriter;
+pub(crate) type ChildStdout = PipeReader;
+pub(crate) type ChildStderr = PipeReader;

--- a/src/native_mux_impl/stdio.rs
+++ b/src/native_mux_impl/stdio.rs
@@ -3,15 +3,12 @@ use crate::{stdio::StdioImpl, Error, Stdio};
 use std::{
     fs::{File, OpenOptions},
     io,
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
+    os::unix::io::{AsRawFd, OwnedFd, RawFd},
 };
 
 use libc::{c_int, fcntl, F_GETFL, F_SETFL, O_NONBLOCK};
 use once_cell::sync::OnceCell;
-use tokio::{
-    io::{AsyncRead, AsyncWrite, ReadBuf},
-    net::unix::pipe::{pipe, Receiver as PipeReader, Sender as PipeWriter},
-};
+use tokio::net::unix::pipe::{pipe, Receiver as PipeReader, Sender as PipeWriter};
 
 fn create_pipe() -> Result<(PipeReader, PipeWriter), Error> {
     pipe().map_err(Error::ChildIo).map(|(w, r)| (r, w))
@@ -65,15 +62,6 @@ impl Fd {
             Borrowed(rawfd) => Ok(*rawfd),
             Null => get_null_fd(),
         }
-    }
-
-    /// # Safety
-    ///
-    /// `T::into_raw_fd` must return a valid fd and transfers
-    /// the ownershipt of it.
-    unsafe fn new_owned<T: IntoRawFd>(fd: T) -> Result<Self, Error> {
-        let raw_fd = fd.into_raw_fd();
-        Ok(Fd::Owned(OwnedFd::from_raw_fd(raw_fd)))
     }
 }
 

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -5,7 +5,7 @@ use super::native_mux_impl;
 
 use std::fs::File;
 use std::io;
-use std::os::unix::io::{AsFd, BorrowedFd, AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::pin::Pin;
 use std::process;
 use std::task::{Context, Poll};

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -176,7 +176,7 @@ macro_rules! impl_from_impl_child_io {
             type Error = Error;
 
             fn try_from(arg: tokio::process::$type) -> Result<Self, Self::Error> {
-                let fd = arg.as_fd().try_clone_to_owned().map_err(Error::ChildIo)?;
+                let fd = arg.into_owned_fd().map_err(Error::ChildIo)?;
 
                 <$inner>::from_owned_fd(fd)
                     .map(Self)

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -64,21 +64,6 @@ impl Stdio {
         Self(StdioImpl::Fd(OwnedFd::from_raw_fd(fd), true))
     }
 }
-/// **Deprecated, use [`Stdio::from_raw_fd_owned`] instead.**
-///
-/// FromRawFd takes ownership of the fd passed in
-/// and closes the fd on drop.
-///
-/// NOTE that the fd must be in blocking mode, otherwise
-/// ssh might not flush all output since it considers
-/// (`EAGAIN`/`EWOULDBLOCK`) as an error
-#[allow(useless_deprecated)]
-#[deprecated(since = "0.9.8", note = "Use Stdio::from_raw_fd_owned instead")]
-impl FromRawFd for Stdio {
-    unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self(StdioImpl::Fd(OwnedFd::from_raw_fd(fd), false))
-    }
-}
 impl From<Stdio> for process::Stdio {
     fn from(stdio: Stdio) -> Self {
         match stdio.0 {

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -5,7 +5,7 @@ use super::native_mux_impl;
 
 use std::fs::File;
 use std::io;
-use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::pin::Pin;
 use std::process;
 use std::task::{Context, Poll};
@@ -71,11 +71,7 @@ impl From<Stdio> for process::Stdio {
             StdioImpl::Null => process::Stdio::null(),
             StdioImpl::Pipe => process::Stdio::piped(),
             StdioImpl::Inherit => process::Stdio::inherit(),
-
-            // safety: StdioImpl(fd) is only constructed from known-valid and
-            // owned file descriptors by virtue of the safety requirement
-            // for invoking from_raw_fd.
-            StdioImpl::Fd(fd) => unsafe { process::Stdio::from_raw_fd(IntoRawFd::into_raw_fd(fd)) },
+            StdioImpl::Fd(fd) => process::Stdio::from(fd),
         }
     }
 }


### PR DESCRIPTION
also remove deprecated functions, and replace `From<tokio::proces::Child*>`
with `TryFrom<tokio::proces::Child*>`, since the converison is falliable.

Also remove `IntoRawFd` for `Child*` since the conversion is falliable.