### PR TITLE
Remove dep tokio-pipe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,7 @@ tempfile = "3.9.0"
 shell-escape = "0.1.5"
 thiserror = "1.0.30"
 
-tokio = { version = "1", features = [ "process", "io-util", "macros" ] }
-tokio-pipe = "0.2.8"
+tokio = { version = "1.36.0", features = [ "process", "io-util", "macros", "net" ] }
 
 once_cell = "1.8.0"
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -69,7 +69,7 @@ pub trait OverSsh {
     /// ###  Examples
     ///
     /// 1. Consider the implementation of `OverSsh` for `std::process::Command`. Let's build a
-    /// `ls -l -a -h` command and execute it over an SSH session.
+    ///    `ls -l -a -h` command and execute it over an SSH session.
     ///
     /// ```no_run
     /// # #[tokio::main(flavor = "current_thread")]
@@ -93,7 +93,7 @@ pub trait OverSsh {
     ///
     /// ```
     /// 2. Building a command with environment variables or a current working directory set will
-    /// results in an error.
+    ///    results in an error.
     ///
     /// ```no_run
     /// # #[tokio::main(flavor = "current_thread")]

--- a/src/native_mux_impl/stdio.rs
+++ b/src/native_mux_impl/stdio.rs
@@ -3,15 +3,15 @@ use crate::{stdio::StdioImpl, Error, Stdio};
 use std::{
     fs::{File, OpenOptions},
     io,
-    os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd},
+    os::unix::io::{AsRawFd, OwnedFd, RawFd},
 };
 
 use libc::{c_int, fcntl, F_GETFL, F_SETFL, O_NONBLOCK};
 use once_cell::sync::OnceCell;
-use tokio_pipe::{pipe, PipeRead, PipeWrite};
+use tokio::net::unix::pipe::{pipe, Receiver as PipeReader, Sender as PipeWriter};
 
-fn create_pipe() -> Result<(PipeRead, PipeWrite), Error> {
-    pipe().map_err(Error::ChildIo)
+fn create_pipe() -> Result<(PipeReader, PipeWriter), Error> {
+    pipe().map_err(Error::ChildIo).map(|(w, r)| (r, w))
 }
 
 /// Open "/dev/null" with RW.
@@ -63,38 +63,27 @@ impl Fd {
             Null => get_null_fd(),
         }
     }
+}
 
-    /// # Safety
-    ///
-    /// `T::into_raw_fd` must return a valid fd and transfers
-    /// the ownershipt of it.
-    unsafe fn new_owned<T: IntoRawFd>(fd: T) -> Result<Self, Error> {
-        let raw_fd = fd.into_raw_fd();
-        Ok(Fd::Owned(OwnedFd::from_raw_fd(raw_fd)))
+impl TryFrom<PipeReader> for Fd {
+    type Error = Error;
+
+    fn try_from(pipe_reader: PipeReader) -> Result<Self, Error> {
+        pipe_reader
+            .into_blocking_fd()
+            .map_err(Error::ChildIo)
+            .map(Fd::Owned)
     }
 }
 
-impl TryFrom<PipeRead> for Fd {
+impl TryFrom<PipeWriter> for Fd {
     type Error = Error;
 
-    fn try_from(pipe_read: PipeRead) -> Result<Self, Error> {
-        // Safety:
-        //
-        // PipeRead::into_raw_fd returns a valid fd and transfers the
-        // ownership of it.
-        unsafe { Self::new_owned(pipe_read) }
-    }
-}
-
-impl TryFrom<PipeWrite> for Fd {
-    type Error = Error;
-
-    fn try_from(pipe_write: PipeWrite) -> Result<Self, Error> {
-        // Safety:
-        //
-        // PipeWrite::into_raw_fd returns a valid fd and transfers the
-        // ownership of it.
-        unsafe { Self::new_owned(pipe_write) }
+    fn try_from(pipe_writer: PipeWriter) -> Result<Self, Error> {
+        pipe_writer
+            .into_blocking_fd()
+            .map_err(Error::ChildIo)
+            .map(Fd::Owned)
     }
 }
 
@@ -105,53 +94,44 @@ impl Stdio {
             StdioImpl::Null => Ok((Fd::Null, None)),
             StdioImpl::Pipe => {
                 let (read, write) = create_pipe()?;
-
-                // read end will be sent to ssh multiplex server
-                // and it expects blocking fd.
-                set_blocking(read.as_raw_fd())?;
                 Ok((read.try_into()?, Some(write)))
             }
-            StdioImpl::Fd(fd, owned) => {
+            StdioImpl::Fd(fd) => {
                 let raw_fd = fd.as_raw_fd();
-                if *owned {
-                    set_blocking(raw_fd)?;
-                }
+                set_blocking(raw_fd)?;
                 Ok((Fd::Borrowed(raw_fd), None))
             }
         }
     }
 
-    fn to_output(&self, get_inherit_rawfd: fn() -> RawFd) -> Result<(Fd, Option<PipeRead>), Error> {
+    fn to_output(
+        &self,
+        get_inherit_rawfd: fn() -> RawFd,
+    ) -> Result<(Fd, Option<PipeReader>), Error> {
         match &self.0 {
             StdioImpl::Inherit => Ok((Fd::Borrowed(get_inherit_rawfd()), None)),
             StdioImpl::Null => Ok((Fd::Null, None)),
             StdioImpl::Pipe => {
                 let (read, write) = create_pipe()?;
-
-                // write end will be sent to ssh multiplex server
-                // and it expects blocking fd.
-                set_blocking(write.as_raw_fd())?;
                 Ok((write.try_into()?, Some(read)))
             }
-            StdioImpl::Fd(fd, owned) => {
+            StdioImpl::Fd(fd) => {
                 let raw_fd = fd.as_raw_fd();
-                if *owned {
-                    set_blocking(raw_fd)?;
-                }
+                set_blocking(raw_fd)?;
                 Ok((Fd::Borrowed(raw_fd), None))
             }
         }
     }
 
-    pub(crate) fn to_stdout(&self) -> Result<(Fd, Option<PipeRead>), Error> {
+    pub(crate) fn to_stdout(&self) -> Result<(Fd, Option<PipeReader>), Error> {
         self.to_output(|| io::stdout().as_raw_fd())
     }
 
-    pub(crate) fn to_stderr(&self) -> Result<(Fd, Option<PipeRead>), Error> {
+    pub(crate) fn to_stderr(&self) -> Result<(Fd, Option<PipeReader>), Error> {
         self.to_output(|| io::stderr().as_raw_fd())
     }
 }
 
-pub(crate) type ChildStdin = PipeWrite;
-pub(crate) type ChildStdout = PipeRead;
-pub(crate) type ChildStderr = PipeRead;
+pub(crate) type ChildStdin = PipeWriter;
+pub(crate) type ChildStdout = PipeReader;
+pub(crate) type ChildStderr = PipeReader;

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -5,11 +5,14 @@ use super::native_mux_impl;
 
 use std::fs::File;
 use std::io;
-use std::os::unix::io::{AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::pin::Pin;
 use std::process;
 use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::unix::pipe::{Receiver as PipeReader, Sender as PipeWriter},
+};
 
 #[derive(Debug)]
 pub(crate) enum StdioImpl {
@@ -18,7 +21,7 @@ pub(crate) enum StdioImpl {
     /// Read/Write to a newly created pipe
     Pipe,
     /// Read/Write to custom fd
-    Fd(OwnedFd, bool),
+    Fd(OwnedFd),
     /// Inherit stdin/stdout/stderr
     Inherit,
 }
@@ -58,44 +61,24 @@ impl Stdio {
     ///
     /// * `fd` - must be a valid fd and must give its ownership to `Stdio`.
     pub unsafe fn from_raw_fd_owned(fd: RawFd) -> Self {
-        Self(StdioImpl::Fd(OwnedFd::from_raw_fd(fd), true))
+        Self(StdioImpl::Fd(OwnedFd::from_raw_fd(fd)))
     }
 }
-/// **Deprecated, use [`Stdio::from_raw_fd_owned`] instead.**
-///
-/// FromRawFd takes ownership of the fd passed in
-/// and closes the fd on drop.
-///
-/// NOTE that the fd must be in blocking mode, otherwise
-/// ssh might not flush all output since it considers
-/// (`EAGAIN`/`EWOULDBLOCK`) as an error
-#[allow(useless_deprecated)]
-#[deprecated(since = "0.9.8", note = "Use Stdio::from_raw_fd_owned instead")]
-impl FromRawFd for Stdio {
-    unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self(StdioImpl::Fd(OwnedFd::from_raw_fd(fd), false))
-    }
-}
+
 impl From<Stdio> for process::Stdio {
     fn from(stdio: Stdio) -> Self {
         match stdio.0 {
             StdioImpl::Null => process::Stdio::null(),
             StdioImpl::Pipe => process::Stdio::piped(),
             StdioImpl::Inherit => process::Stdio::inherit(),
-
-            // safety: StdioImpl(fd) is only constructed from known-valid and
-            // owned file descriptors by virtue of the safety requirement
-            // for invoking from_raw_fd.
-            StdioImpl::Fd(fd, _) => unsafe {
-                process::Stdio::from_raw_fd(IntoRawFd::into_raw_fd(fd))
-            },
+            StdioImpl::Fd(fd) => process::Stdio::from(fd),
         }
     }
 }
 
 impl From<OwnedFd> for Stdio {
     fn from(fd: OwnedFd) -> Self {
-        Self(StdioImpl::Fd(fd, true))
+        Self(StdioImpl::Fd(fd))
     }
 }
 
@@ -103,42 +86,32 @@ macro_rules! impl_from_for_stdio {
     ($type:ty) => {
         impl From<$type> for Stdio {
             fn from(arg: $type) -> Self {
-                let fd = arg.into_raw_fd();
-                // safety: $type must have a valid into_raw_fd implementation
-                // and must not be RawFd.
-                Self(StdioImpl::Fd(unsafe { OwnedFd::from_raw_fd(fd) }, true))
-            }
-        }
-    };
-    (deprecated $type:ty) => {
-        #[allow(useless_deprecated)]
-        #[deprecated(
-            since = "0.9.8",
-            note = "Use From<OwnedFd> for Stdio or Stdio::from_raw_fd_owned instead"
-        )]
-        /// **Deprecated, use `From<OwnedFd> for Stdio` or
-        /// [`Stdio::from_raw_fd_owned`] instead.**
-        impl From<$type> for Stdio {
-            fn from(arg: $type) -> Self {
-                let fd = arg.into_raw_fd();
-                // safety: $type must have a valid into_raw_fd implementation
-                // and must not be RawFd.
-                Self(StdioImpl::Fd(unsafe { OwnedFd::from_raw_fd(fd) }, true))
+                Self(StdioImpl::Fd(arg.into()))
             }
         }
     };
 }
 
-impl_from_for_stdio!(deprecated tokio_pipe::PipeWrite);
-impl_from_for_stdio!(deprecated tokio_pipe::PipeRead);
+macro_rules! impl_try_from_for_stdio {
+    ($type:ty) => {
+        impl TryFrom<$type> for Stdio {
+            type Error = Error;
+            fn try_from(arg: $type) -> Result<Self, Self::Error> {
+                Ok(Self(StdioImpl::Fd(
+                    arg.into_owned_fd().map_err(Error::ChildIo)?,
+                )))
+            }
+        }
+    };
+}
 
 impl_from_for_stdio!(process::ChildStdin);
 impl_from_for_stdio!(process::ChildStdout);
 impl_from_for_stdio!(process::ChildStderr);
 
-impl_from_for_stdio!(ChildStdin);
-impl_from_for_stdio!(ChildStdout);
-impl_from_for_stdio!(ChildStderr);
+impl_try_from_for_stdio!(ChildStdin);
+impl_try_from_for_stdio!(ChildStdout);
+impl_try_from_for_stdio!(ChildStderr);
 
 impl_from_for_stdio!(File);
 
@@ -148,8 +121,7 @@ macro_rules! impl_try_from_tokio_process_child_for_stdio {
             type Error = Error;
 
             fn try_from(arg: tokio::process::$type) -> Result<Self, Self::Error> {
-                let wrapper: $type = TryFromChildIo::try_from(arg)?;
-                Ok(wrapper.0.into())
+                arg.into_owned_fd().map_err(Error::ChildIo).map(Into::into)
             }
         }
     };
@@ -161,15 +133,15 @@ impl_try_from_tokio_process_child_for_stdio!(ChildStderr);
 
 /// Input for the remote child.
 #[derive(Debug)]
-pub struct ChildStdin(tokio_pipe::PipeWrite);
+pub struct ChildStdin(PipeWriter);
 
 /// Stdout for the remote child.
 #[derive(Debug)]
-pub struct ChildStdout(tokio_pipe::PipeRead);
+pub struct ChildStdout(PipeReader);
 
 /// Stderr for the remote child.
 #[derive(Debug)]
-pub struct ChildStderr(tokio_pipe::PipeRead);
+pub struct ChildStderr(PipeReader);
 
 pub(crate) trait TryFromChildIo<T>: Sized {
     type Error;
@@ -183,17 +155,9 @@ macro_rules! impl_from_impl_child_io {
             type Error = Error;
 
             fn try_from(arg: tokio::process::$type) -> Result<Self, Self::Error> {
-                let fd = arg.as_raw_fd();
+                let fd = arg.into_owned_fd().map_err(Error::ChildIo)?;
 
-                // safety: arg.as_raw_fd() is guaranteed to return a valid fd.
-                let fd = unsafe { BorrowedFd::borrow_raw(fd) };
-
-                let fd = fd
-                    .try_clone_to_owned()
-                    .map_err(Error::ChildIo)?
-                    .into_raw_fd();
-
-                <$inner>::from_raw_fd_checked(fd)
+                <$inner>::from_owned_fd(fd)
                     .map(Self)
                     .map_err(Error::ChildIo)
             }
@@ -212,9 +176,9 @@ macro_rules! impl_from_impl_child_io {
     };
 }
 
-impl_from_impl_child_io!(process, ChildStdin, tokio_pipe::PipeWrite);
-impl_from_impl_child_io!(process, ChildStdout, tokio_pipe::PipeRead);
-impl_from_impl_child_io!(process, ChildStderr, tokio_pipe::PipeRead);
+impl_from_impl_child_io!(process, ChildStdin, PipeWriter);
+impl_from_impl_child_io!(process, ChildStdout, PipeReader);
+impl_from_impl_child_io!(process, ChildStderr, PipeReader);
 
 impl_from_impl_child_io!(native_mux, ChildStdin);
 impl_from_impl_child_io!(native_mux, ChildStdout);
@@ -229,17 +193,27 @@ macro_rules! impl_child_stdio {
         }
     };
 
-    (IntoRawFd, $type:ty) => {
-        impl IntoRawFd for $type {
-            fn into_raw_fd(self) -> RawFd {
-                self.0.into_raw_fd()
+    (AsFd, $type:ty) => {
+        impl AsFd for $type {
+            fn as_fd(&self) -> BorrowedFd<'_> {
+                self.0.as_fd()
+            }
+        }
+    };
+
+    (into_owned_fd, $type:ty) => {
+        impl $type {
+            /// Convert into an owned fd, it'd be deregisted from tokio and in blocking mode.
+            pub fn into_owned_fd(self) -> io::Result<OwnedFd> {
+                self.0.into_blocking_fd()
             }
         }
     };
 
     (AsyncRead, $type:ty) => {
         impl_child_stdio!(AsRawFd, $type);
-        impl_child_stdio!(IntoRawFd, $type);
+        impl_child_stdio!(AsFd, $type);
+        impl_child_stdio!(into_owned_fd, $type);
 
         impl AsyncRead for $type {
             fn poll_read(
@@ -254,7 +228,8 @@ macro_rules! impl_child_stdio {
 
     (AsyncWrite, $type: ty) => {
         impl_child_stdio!(AsRawFd, $type);
-        impl_child_stdio!(IntoRawFd, $type);
+        impl_child_stdio!(AsFd, $type);
+        impl_child_stdio!(into_owned_fd, $type);
 
         impl AsyncWrite for $type {
             fn poll_write(


### PR DESCRIPTION
* Remove dep tokio-pipe
* Remove deprecated functions
* Replace `From<tokio::proces::Child*>` with `TryFrom<tokio::proces::Child*>`, since the converison is falliable.
* Remove `IntoRawFd` for `Child*` since the conversion is falliable.
* Optimize `TryFromChildIo<tokio::process::Child*> for Child*`
* Rm unused functions and imports in native_mux_impl/stdio
* Impl `AsFd` for `Child*`
* Rm deprecated `FromRawFd` for `Stdio`
* Rm unused field in variant `Stdio::Fd`
* Fix clippy lints
* Remove unnecessary `unsafe`
* Bump dep tokio to 1.36.0