### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.6](https://github.com/openssh-rust/openssh/compare/v0.10.5...v0.10.6) - 2024-08-10
+## [0.11.0](https://github.com/openssh-rust/openssh/compare/v0.10.5...v0.10.6) - 2024-08-10
 
 - Remove dep tokio-pipe (#156)
 - Remove deprecated functions (#156)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.6](https://github.com/openssh-rust/openssh/compare/v0.10.5...v0.10.6) - 2024-08-10
+## [0.11.6](https://github.com/openssh-rust/openssh/compare/v0.10.5...v0.10.6) - 2024-08-10
 
-### Other
-- Remove dep tokio-pipe ([#155](https://github.com/openssh-rust/openssh/pull/155)) ([#156](https://github.com/openssh-rust/openssh/pull/156))
+- Remove dep tokio-pipe (#156)
+- Remove deprecated functions (#156)
+- Replace `From<tokio::proces::Child*>`
+with `TryFrom<tokio::proces::Child*>`, since the converison is falliable (#156)
+- Remove `IntoRawFd` for `Child*` since the conversion is falliable (#156)
 
 ## [0.10.5](https://github.com/openssh-rust/openssh/compare/v0.10.4...v0.10.5) - 2024-08-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh"
-version = "0.10.6"
+version = "0.11.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -5,6 +5,18 @@ use crate::*;
 #[doc(hidden)]
 pub mod unreleased {}
 
+/// # Changed
+/// - Remove dep tokio-pipe (#156)
+/// - Remove deprecated functions (#156)
+/// - Replace `From<tokio::proces::Child*>`
+///   with `TryFrom<tokio::proces::Child*>`, since the converison is falliable (#156)
+/// - Remove `IntoRawFd` for `Child*` since the conversion is falliable (#156)
+pub mod v0_11_0{}
+
+/// ## Changed
+///  - Add missing feature doc for `Session::new*`
+pub mod v0_10_5 {}
+
 /// ## Changed
 /// - Added new fn [`Session::control_persist`] to set the `ControlPersist` option of
 ///   the master ssh connection.

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -11,7 +11,7 @@ pub mod unreleased {}
 /// - Replace `From<tokio::proces::Child*>`
 ///   with `TryFrom<tokio::proces::Child*>`, since the converison is falliable (#156)
 /// - Remove `IntoRawFd` for `Child*` since the conversion is falliable (#156)
-pub mod v0_11_0{}
+pub mod v0_11_0 {}
 
 /// ## Changed
 ///  - Add missing feature doc for `Session::new*`


### PR DESCRIPTION
- Remove dep tokio-pipe (#156)
- Remove deprecated functions (#156)
- Replace `From<tokio::proces::Child*>`
with `TryFrom<tokio::proces::Child*>`, since the converison is falliable (#156)
- Remove `IntoRawFd` for `Child*` since the conversion is falliable (#156)
