### PR TITLE
Feat: Closing an existing port forward

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { version = "1.36.0", features = [ "process", "io-util", "macros", "net"
 
 once_cell = "1.8.0"
 
-openssh-mux-client = { version = "0.17.0", optional = true }
+openssh-mux-client = { version = "0.17.6", optional = true }
 
 libc = "0.2.137"
 

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -67,15 +67,6 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) async fn cancel_port_forward(
-        &self,
-        forward_type: crate::ForwardType,
-        listen_socket: crate::Socket<'_>,
-        connect_socket: crate::Socket<'_>,
-    ) -> Result<(), Error> {
-        unimplemented!()
-    }
-
     async fn close_impl(&self) -> Result<(), Error> {
         Connection::connect(&self.ctl)
             .await?

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -67,13 +67,17 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) async fn cancel_port_forward(
+    pub(crate) async fn close_port_forward(
         &self,
         forward_type: crate::ForwardType,
         listen_socket: crate::Socket<'_>,
         connect_socket: crate::Socket<'_>,
     ) -> Result<(), Error> {
-        unimplemented!("Port forwarding cancellation is not implemented yet")
+        Connection::connect(&self.ctl).await?.close_port_forward(
+            forward_type.into(),
+            &listen_socket.into(),
+            &connect_socket.into(),
+        )
     }
 
     async fn close_impl(&self) -> Result<(), Error> {

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -73,11 +73,16 @@ impl Session {
         listen_socket: crate::Socket<'_>,
         connect_socket: crate::Socket<'_>,
     ) -> Result<(), Error> {
-        Connection::connect(&self.ctl).await?.close_port_forward(
-            forward_type.into(),
-            &listen_socket.into(),
-            &connect_socket.into(),
-        )
+        Connection::connect(&self.ctl)
+            .await?
+            .close_port_forward(
+                forward_type.into(),
+                &listen_socket.into(),
+                &connect_socket.into(),
+            )
+            .await?;
+
+        Ok(())
     }
 
     async fn close_impl(&self) -> Result<(), Error> {

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -67,6 +67,15 @@ impl Session {
         Ok(())
     }
 
+    pub(crate) async fn cancel_port_forward(
+        &self,
+        forward_type: crate::ForwardType,
+        listen_socket: crate::Socket<'_>,
+        connect_socket: crate::Socket<'_>,
+    ) -> Result<(), Error> {
+        unimplemented!("Port forwarding cancellation is not implemented yet")
+    }
+
     async fn close_impl(&self) -> Result<(), Error> {
         Connection::connect(&self.ctl)
             .await?

--- a/src/native_mux_impl/session.rs
+++ b/src/native_mux_impl/session.rs
@@ -67,6 +67,15 @@ impl Session {
         Ok(())
     }
 
+    pub(crate) async fn cancel_port_forward(
+        &self,
+        forward_type: crate::ForwardType,
+        listen_socket: crate::Socket<'_>,
+        connect_socket: crate::Socket<'_>,
+    ) -> Result<(), Error> {
+        unimplemented!()
+    }
+
     async fn close_impl(&self) -> Result<(), Error> {
         Connection::connect(&self.ctl)
             .await?

--- a/src/process_impl/session.rs
+++ b/src/process_impl/session.rs
@@ -139,7 +139,7 @@ impl Session {
         }
     }
 
-    pub(crate) async fn cancel_port_forward(
+    pub(crate) async fn close_port_forward(
         &self,
         forward_type: ForwardType,
         listen_socket: Socket<'_>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -493,6 +493,7 @@ impl Session {
     ///
     /// Currently, cancelling port forwarding is only supported for the process mux impl.
     #[cfg(feature = "process-mux")]
+    #[cfg(not(feature = "native-mux"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub async fn cancel_port_forward(
         &self,

--- a/src/session.rs
+++ b/src/session.rs
@@ -492,8 +492,6 @@ impl Session {
     /// The same set of arguments should be passed as when the port forwarding was requested.
     ///
     /// Currently, cancelling port forwarding is only supported for the process mux impl.
-    #[cfg(not(feature = "native-mux"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub async fn cancel_port_forward(
         &self,
         forward_type: impl Into<ForwardType>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -492,6 +492,8 @@ impl Session {
     /// The same set of arguments should be passed as when the port forwarding was requested.
     ///
     /// Currently, cancelling port forwarding is only supported for the process mux impl.
+    #[cfg(feature = "process-mux")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub async fn cancel_port_forward(
         &self,
         forward_type: impl Into<ForwardType>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -471,9 +471,6 @@ impl Session {
     ///
     /// Otherwise, `listen_socket` on the remote machine will be forwarded to `connect_socket`
     /// on the local machine.
-    ///
-    /// Currently, there is no way of stopping a port forwarding due to the fact that
-    /// openssh multiplex server/master does not support this.
     pub async fn request_port_forward(
         &self,
         forward_type: impl Into<ForwardType>,
@@ -491,6 +488,10 @@ impl Session {
     }
 
     /// Request to cancel a local/remote port forwarding.
+    ///
+    /// The same set of arguments should be passed as when the port forwarding was requested.
+    ///
+    /// Currently, cancelling a port forwarding is only supported for the process mux impl.
     pub async fn cancel_port_forward(
         &self,
         forward_type: impl Into<ForwardType>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -490,6 +490,23 @@ impl Session {
         })
     }
 
+    /// Request to cancel a local/remote port forwarding.
+    pub async fn cancel_port_forward(
+        &self,
+        forward_type: impl Into<ForwardType>,
+        listen_socket: impl Into<Socket<'_>>,
+        connect_socket: impl Into<Socket<'_>>,
+    ) -> Result<(), Error> {
+        delegate!(&self.0, imp, {
+            imp.cancel_port_forward(
+                forward_type.into(),
+                listen_socket.into(),
+                connect_socket.into(),
+            )
+            .await
+        })
+    }
+
     /// Terminate the remote connection.
     ///
     /// This destructor terminates the ssh multiplex server

--- a/src/session.rs
+++ b/src/session.rs
@@ -487,13 +487,11 @@ impl Session {
         })
     }
 
-    /// Request to cancel a local/remote port forwarding.
+    /// Cancel a previously established local/remote port forwarding.
     ///
     /// The same set of arguments should be passed as when the port forwarding was requested.
     ///
     /// Currently, cancelling port forwarding is only supported for the process mux impl.
-    #[cfg(feature = "process-mux")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub async fn cancel_port_forward(
         &self,
         forward_type: impl Into<ForwardType>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -492,7 +492,6 @@ impl Session {
     /// The same set of arguments should be passed as when the port forwarding was requested.
     ///
     /// Currently, cancelling port forwarding is only supported for the process mux impl.
-    #[cfg(feature = "process-mux")]
     #[cfg(not(feature = "native-mux"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub async fn cancel_port_forward(

--- a/src/session.rs
+++ b/src/session.rs
@@ -487,19 +487,17 @@ impl Session {
         })
     }
 
-    /// Cancel a previously established local/remote port forwarding.
+    /// Close a previously established local/remote port forwarding.
     ///
     /// The same set of arguments should be passed as when the port forwarding was requested.
-    ///
-    /// Currently, cancelling port forwarding is only supported for the process mux impl.
-    pub async fn cancel_port_forward(
+    pub async fn close_port_forward(
         &self,
         forward_type: impl Into<ForwardType>,
         listen_socket: impl Into<Socket<'_>>,
         connect_socket: impl Into<Socket<'_>>,
     ) -> Result<(), Error> {
         delegate!(&self.0, imp, {
-            imp.cancel_port_forward(
+            imp.close_port_forward(
                 forward_type.into(),
                 listen_socket.into(),
                 connect_socket.into(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -491,7 +491,9 @@ impl Session {
     ///
     /// The same set of arguments should be passed as when the port forwarding was requested.
     ///
-    /// Currently, cancelling a port forwarding is only supported for the process mux impl.
+    /// Currently, cancelling port forwarding is only supported for the process mux impl.
+    #[cfg(feature = "process-mux")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "process-mux")))]
     pub async fn cancel_port_forward(
         &self,
         forward_type: impl Into<ForwardType>,

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -854,11 +854,13 @@ async fn remote_socket_forward() {
         drop(output);
         drop(output_listener);
 
-        eprintln!("Canceling port forward");
-        session
-            .cancel_port_forward(ForwardType::Remote, (loopback(), *port), &*unix_socket)
-            .await
-            .unwrap();
+        if !cfg!(feature = "native-mux") {
+            eprintln!("Canceling port forward");
+            session
+                .cancel_port_forward(ForwardType::Remote, (loopback(), *port), &*unix_socket)
+                .await
+                .unwrap();
+        }
 
         eprintln!("Waiting for session to end");
         let output = child.wait_with_output().await.unwrap();
@@ -869,7 +871,6 @@ async fn remote_socket_forward() {
 
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]
-#[cfg(not(feature = "native-mux"))]
 async fn local_socket_forward() {
     let sessions = connects().await;
     for (session, port) in sessions.iter().zip([1433, 1432]) {
@@ -909,11 +910,13 @@ async fn local_socket_forward() {
 
         drop(output);
 
-        eprintln!("Canceling port forward");
-        session
-            .cancel_port_forward(ForwardType::Local, &*unix_socket, (loopback(), port))
-            .await
-            .unwrap();
+        if !cfg!(feature = "native-mux") {
+            eprintln!("Canceling port forward");
+            session
+                .cancel_port_forward(ForwardType::Local, &*unix_socket, (loopback(), port))
+                .await
+                .unwrap();
+        }
 
         eprintln!("Trying to connect again");
         let e = UnixStream::connect(&unix_socket).await.unwrap_err();

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -858,8 +858,9 @@ async fn remote_socket_forward() {
             .unwrap();
 
         eprintln!("Trying to connect again");
-        let e = UnixStream::connect(&unix_socket).await.unwrap_err();
-        assert_eq!(e.kind(), io::ErrorKind::ConnectionRefused);
+        let n = output.read(&mut buffer).await.unwrap();
+        eprintln!("Buffer: {:?}", &buffer[..n]);
+        assert_eq!(n, 0);
 
         drop(output);
         drop(output_listener);

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -858,7 +858,8 @@ async fn remote_socket_forward() {
             .unwrap();
 
         eprintln!("Trying to connect again");
-        assert_eq!(output.read(&mut buffer).await.unwrap(), 0);
+        let e = output.try_read(&mut buffer).unwrap_err();
+        assert_eq!(e.kind(), io::ErrorKind::WouldBlock);
 
         drop(output);
         drop(output_listener);

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -829,7 +829,7 @@ async fn remote_socket_forward() {
 
         eprintln!("Creating remote process");
         let cmd = format!(
-            "echo -e '0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n' | nc localhost {} >/dev/stderr",
+            "echo -e '0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10' | nc localhost {} >/dev/stderr",
             port
         );
         let child = session
@@ -858,9 +858,7 @@ async fn remote_socket_forward() {
             .unwrap();
 
         eprintln!("Trying to connect again");
-        let n = output.read(&mut buffer).await.unwrap();
-        eprintln!("Buffer: {:?}", &buffer[..n]);
-        assert_eq!(n, 0);
+        assert_eq!(output.read(&mut buffer).await.unwrap(), 0);
 
         drop(output);
         drop(output_listener);

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -852,6 +852,7 @@ async fn remote_socket_forward() {
         assert_eq!(DATA, &buffer);
 
         drop(output);
+        drop(output_listener);
 
         eprintln!("Canceling port forward");
         session
@@ -860,10 +861,8 @@ async fn remote_socket_forward() {
             .unwrap();
 
         eprintln!("Trying to listen again");
-        let e = output_listener.accept().await.unwrap_err();
+        let e = UnixListener::bind(&unix_socket).unwrap_err();
         assert_eq!(e.kind(), io::ErrorKind::ConnectionRefused);
-
-        drop(output_listener);
 
         eprintln!("Waiting for session to end");
         let output = child.wait_with_output().await.unwrap();

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -916,11 +916,11 @@ async fn local_socket_forward() {
                 .cancel_port_forward(ForwardType::Local, &*unix_socket, (loopback(), port))
                 .await
                 .unwrap();
-        }
 
-        eprintln!("Trying to connect again");
-        let e = UnixStream::connect(&unix_socket).await.unwrap_err();
-        assert_eq!(e.kind(), io::ErrorKind::ConnectionRefused);
+            eprintln!("Trying to connect again");
+            let e = UnixStream::connect(&unix_socket).await.unwrap_err();
+            assert_eq!(e.kind(), io::ErrorKind::ConnectionRefused);
+        }
 
         eprintln!("Waiting for session to end");
         let output = child.wait_with_output().await.unwrap();

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -860,10 +860,6 @@ async fn remote_socket_forward() {
             .await
             .unwrap();
 
-        eprintln!("Trying to listen again");
-        let e = UnixListener::bind(&unix_socket).unwrap_err();
-        assert_eq!(e.kind(), io::ErrorKind::ConnectionRefused);
-
         eprintln!("Waiting for session to end");
         let output = child.wait_with_output().await.unwrap();
         eprintln!("remote_socket_forward: {:#?}", output);
@@ -873,6 +869,7 @@ async fn remote_socket_forward() {
 
 #[tokio::test]
 #[cfg_attr(not(ci), ignore)]
+#[cfg(not(feature = "native-mux"))]
 async fn local_socket_forward() {
     let sessions = connects().await;
     for (session, port) in sessions.iter().zip([1433, 1432]) {

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -858,7 +858,8 @@ async fn remote_socket_forward() {
             .unwrap();
 
         eprintln!("Trying to connect again");
-        assert_eq!(output.read(&mut buffer).await.unwrap(), 0);
+        let e = UnixStream::connect(&unix_socket).await.unwrap_err();
+        assert_eq!(e.kind(), io::ErrorKind::ConnectionRefused);
 
         drop(output);
         drop(output_listener);


### PR DESCRIPTION
I implemented port forwarding cancellation for the process mux session implementation.

CC. @NobodyXu 

Closes #110 