### PR TITLE
feat: Log SSH commands

### DIFF
--- a/src/native_mux_impl/command.rs
+++ b/src/native_mux_impl/command.rs
@@ -73,6 +73,9 @@ impl Command {
 
         let cmd = NonZeroByteSlice::new(&self.cmd).ok_or(Error::InvalidCommand)?;
 
+        #[cfg(feature = "tracing")]
+        tracing::debug!(cmd = String::from_utf8_lossy(cmd.into_inner()).as_ref());
+
         let session = Session::builder()
             .cmd(Cow::Borrowed(cmd))
             .subsystem(self.subsystem)

--- a/src/process_impl/command.rs
+++ b/src/process_impl/command.rs
@@ -50,6 +50,9 @@ impl Command {
         ),
         Error,
     > {
+        #[cfg(feature = "tracing")]
+        tracing::debug!(cmd = ?self.builder.as_std());
+
         let mut channel = self.builder.spawn().map_err(Error::Ssh)?;
 
         let child_stdin = channel.stdin.take();


### PR DESCRIPTION
@NobodyXu 

As per https://github.com/openssh-rust/openssh/issues/174.

This PR adds logging for the actual SSH commands through the `tracing` crate.
The result looks like this:

Regular:
```
2025-01-08T19:09:46.223524Z DEBUG openssh::process_impl::command: 54: cmd="ssh" "-S" "/Users/Quentin/.local/state/.ssh-connectionguuxlv/master" "-o" "BatchMode=yes" "-T" "-p" "9" "none" "--" "ls" "-rtl"
```

Multiplex:
```
2025-01-08T19:08:44.459856Z DEBUG openssh::native_mux_impl::command: 77: cmd="ls -rtl"
```

Closes #174 