### PR TITLE
fix: encoding of IPv6 addresses in `impl From<SocketAddr> for Socket`

### DIFF
--- a/src/port_forwarding.rs
+++ b/src/port_forwarding.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 
 use std::borrow::Cow;
 use std::fmt;
-use std::net::{self, SocketAddr};
+use std::net::{self, IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 
 /// Type of forwarding
@@ -53,8 +53,12 @@ pub enum Socket<'a> {
 
 impl From<SocketAddr> for Socket<'static> {
     fn from(addr: SocketAddr) -> Self {
+        let host = match addr.ip() {
+            IpAddr::V4(v4) => v4.to_string(),
+            IpAddr::V6(v6) => format!("[{v6}]"),
+        };
         Socket::TcpSocket {
-            host: addr.ip().to_string().into(),
+            host: host.into(),
             port: addr.port(),
         }
     }


### PR DESCRIPTION
This makes the `impl From<SocketAddr> for Socket<'static>` implementation wrap IPv6 addresses in square brackets, so that an address like an address like `2606:4700:4700::1111` port `123` gets encoded as `[2606:4700:4700::1111]:123` instead of `2606:4700:4700::1111:123` as it does now.

This is also what the std `Display` implementation for `SocketAddr` does: https://doc.rust-lang.org/1.91.1/src/core/net/socket_addr.rs.html#678